### PR TITLE
fix: add "passHref" to all next/links to use twin.macro

### DIFF
--- a/apps/website/src/components/MenuBar/MenuBar.tsx
+++ b/apps/website/src/components/MenuBar/MenuBar.tsx
@@ -42,7 +42,7 @@ export const MenuBar: FC = () => {
       <div css={styles.wrapper}>
         <nav css={styles.inner}>
           <section data-testid="menu-bar__logo" css={styles.logo}>
-            <Link href="/" locale={locale}>
+            <Link href="/" locale={locale} passHref>
               <a>
                 <Logo />
               </a>

--- a/apps/website/src/components/PostBasic/PostBasic.tsx
+++ b/apps/website/src/components/PostBasic/PostBasic.tsx
@@ -28,7 +28,7 @@ export const PostBasic: React.FC<PostBasicProps> = ({
 }) => {
   return (
     <Wrapper as={as} css={className}>
-      <Link href={url}>
+      <Link href={url} passHref>
         <a css={styles.titleLink}>
           <h3 css={[styles.title, titleClassName]}>{title}</h3>
         </a>
@@ -49,7 +49,7 @@ export const PostBasic: React.FC<PostBasicProps> = ({
         <Tags css={styles.tags}>
           {tags.map(({ name, slug, id }) => (
             <Tag key={id}>
-              <Link href={getTagUrl(slug)}>
+              <Link href={getTagUrl(slug)} passHref>
                 <a css={styles.tagLink}>#{name}</a>
               </Link>
             </Tag>

--- a/apps/website/src/components/PostCard/PostCard.tsx
+++ b/apps/website/src/components/PostCard/PostCard.tsx
@@ -31,7 +31,7 @@ export const PostCard: React.FC<PostCardProps> = ({
         <Image src={imageUrl} layout="fill" css={styles.image} />
       </div>
       <div css={styles.bodyWrapper}>
-        <Link href={postUrl}>
+        <Link href={postUrl} passHref>
           <a css={styles.titleLink} {...titleLinkProps}>
             <h3 css={styles.title}>{title}</h3>
           </a>
@@ -45,7 +45,7 @@ export const PostCard: React.FC<PostCardProps> = ({
           <Tags css={styles.tags}>
             {tags.map(({ name, href }) => (
               <Tag key={name}>
-                <Link href={href}>
+                <Link href={href} passHref>
                   <a css={styles.tag}>#{name}</a>
                 </Link>
               </Tag>

--- a/apps/website/src/components/SideMenu/SideMenu.tsx
+++ b/apps/website/src/components/SideMenu/SideMenu.tsx
@@ -106,7 +106,7 @@ export const SideMenu = () => {
         <ul css={styles.list}>
           {links.map(({ href, active, itemLabel }) => (
             <li css={styles.listItem} key={href}>
-              <Link href={href}>
+              <Link href={href} passHref>
                 <a onClick={handleClose} css={styles.sideMenuItem(active)}>
                   {itemLabel}
                 </a>

--- a/apps/website/src/components/templates/MdxPost/MdxPost.tsx
+++ b/apps/website/src/components/templates/MdxPost/MdxPost.tsx
@@ -127,7 +127,7 @@ export const MdxPostTemplate: React.FC<MdxPostTemplateProps> = ({
               <Tags>
                 {tags.map((tag) => (
                   <Tag key={tag.id} tw="text-base lg:text-lg">
-                    <Link href={getTagUrl(tag.slug)}>
+                    <Link href={getTagUrl(tag.slug)} passHref>
                       <a tw="underline">#{tag.name}</a>
                     </Link>
                   </Tag>

--- a/apps/website/src/screens/BlogPost/components/SeriesSection/SeriesSection.tsx
+++ b/apps/website/src/screens/BlogPost/components/SeriesSection/SeriesSection.tsx
@@ -61,7 +61,7 @@ export const SeriesSection: React.FC<SeriesSectionProps> = ({
                   data-testid={`post_${id}`}
                   variants={variants.item}
                 >
-                  <Link href={uri}>
+                  <Link href={uri} passHref>
                     <a
                       css={styles.link}
                       aria-hidden={currentState === 'collapsed'}

--- a/apps/website/src/screens/Home/HomePage.tsx
+++ b/apps/website/src/screens/Home/HomePage.tsx
@@ -91,7 +91,7 @@ const PostSection = ({ checkAllLink, posts, title }: PostSectionProps) => {
           </li>
         ))}
       </ul>
-      <Link href={checkAllLink.href}>
+      <Link href={checkAllLink.href} passHref>
         <a css={styles.postCardLink}>{checkAllLink.text}</a>
       </Link>
     </section>


### PR DESCRIPTION
This will solve the anchor tags (links) unfocusable because of missing `href`
https://github.com/ben-rogerson/twin.macro/issues/422#event-4665652754