### PR TITLE
[MDX-PRISM-2] - Refactor: Remove dependencies from bundle

### DIFF
--- a/packages/mdx-prism-2/scripts/_base/esbuild.js
+++ b/packages/mdx-prism-2/scripts/_base/esbuild.js
@@ -1,5 +1,6 @@
 import { dtsPlugin } from 'esbuild-plugin-d.ts';
-import { build } from 'esbuild';
+import { build, analyzeMetafile } from 'esbuild';
+import pkgJson from '../../package.json';
 
 export function runESBuild(options = {}) {
   const commonJs = createConfig({
@@ -15,13 +16,26 @@ export function runESBuild(options = {}) {
     target: 'node12',
   });
 
-  return Promise.all([build(commonJs), build(esm)]);
+  return Promise.all([build(commonJs), build(esm)]).then(
+    async ([cjsOutput, esmOutput]) => {
+      const esmResult = await analyzeMetafile(esmOutput.metafile, {
+        verbose: false,
+      });
+      console.log(esmResult);
+      const cjsResult = await analyzeMetafile(cjsOutput.metafile, {
+        verbose: false,
+      });
+      console.log(cjsResult);
+    },
+  );
 
   function createConfig(overrides = {}) {
     const baseConfig = {
       bundle: true,
       entryPoints: ['src/lib.ts'],
       sourcemap: 'external',
+      metafile: true,
+      external: Object.keys(pkgJson.dependencies),
       ...overrides,
     };
 

--- a/packages/mdx-prism-2/scripts/build/index.sh
+++ b/packages/mdx-prism-2/scripts/build/index.sh
@@ -4,7 +4,7 @@
 ./scripts/clean.sh
 
 # Build itself
-./scripts/build/build.js $1
+NODE_OPTIONS=--experimental-json-modules ./scripts/build/build.js $@
 
 #generate .d.ts files
 yarn tsc


### PR DESCRIPTION
After I've migrated to Esbuild, I forgot to exclude the dependencies from the final bundle.


| File                    | Before | After  | Diff               |
|-------------------------|--------|--------|--------------------|
| dist/esm/mdx-prism-2.js | 1.2mb  | 13.3kb | -1186.7kb (1.19mb) |
| dist/cjs/mdx-prism-2.js | 1.3mb  | 15.0kb | -1285kb (1.29mb)   |