### PR TITLE
[FIX] development mode: load .env file

### DIFF
--- a/apps/lambdas/package.json
+++ b/apps/lambdas/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "algoliasearch": "4.11.0",
     "axios": "0.24.0",
-    "dotenv": "10.0.0",
     "netlify-lambda": "2.0.15"
   },
   "devDependencies": {

--- a/apps/lambdas/src/config/index.ts
+++ b/apps/lambdas/src/config/index.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-require('dotenv').config();
+require('dotenv-flow').config();
 
 export const SETTINGS = {
   algolia: {

--- a/apps/website/scripts/fetchSiteData.mjs
+++ b/apps/website/scripts/fetchSiteData.mjs
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import dotenv from 'dotenv-flow';
+dotenv.config();
 import { generateSiteData } from '@raulfdm/core/generateSiteData';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/package.json
+++ b/package.json
@@ -67,5 +67,8 @@
     "tmpl": "^1.0.5",
     "trim": "^1.0.0",
     "tslib": "^2.1.0"
+  },
+  "dependencies": {
+    "dotenv-flow": "3.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,7 @@ importers:
       babel-jest: 27.4.4
       babel-loader: 8.2.3
       cssnano: 5.0.12
+      dotenv-flow: 3.2.0
       esbuild: 0.14.3
       esbuild-plugin-d.ts: 1.1.0
       eslint: <8.0.0
@@ -63,6 +64,8 @@ importers:
       ts-node: 10.4.0
       tslib: ^2.1.0
       typescript: 4.5.2
+    dependencies:
+      dotenv-flow: 3.2.0
     devDependencies:
       '@babel/core': 7.16.0
       '@babel/eslint-parser': 7.16.3_@babel+core@7.16.0+eslint@7.32.0
@@ -140,12 +143,10 @@ importers:
       '@types/axios': 0.14.0
       algoliasearch: 4.11.0
       axios: ^0.24.0
-      dotenv: 10.0.0
       netlify-lambda: 2.0.15
     dependencies:
       algoliasearch: 4.11.0
       axios: 0.24.0
-      dotenv: 10.0.0
       netlify-lambda: 2.0.15
     devDependencies:
       '@types/algoliasearch': 4.0.0
@@ -8660,9 +8661,11 @@ packages:
       is-obj: 2.0.0
     dev: false
 
-  /dotenv/10.0.0:
-    resolution: {integrity: sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==}
-    engines: {node: '>=10'}
+  /dotenv-flow/3.2.0:
+    resolution: {integrity: sha512-GEB6RrR4AbqDJvNSFrYHqZ33IKKbzkvLYiD5eo4+9aFXr4Y4G+QaFrB/fNp0y6McWBmvaPn3ZNjIufnj8irCtg==}
+    engines: {node: '>= 8.0.0'}
+    dependencies:
+      dotenv: 8.2.0
     dev: false
 
   /dotenv/8.2.0:


### PR DESCRIPTION
Locally, because there's no way of injecting the environment variables, it always fail to generate the site data file.

This works fine on production because the pipeline will inject those env. vars automatically for us.