### PR TITLE
refactor: move back stick to pseudo css

### DIFF
--- a/packages/ui/src/components/Highlight/Highlight.module.css
+++ b/packages/ui/src/components/Highlight/Highlight.module.css
@@ -1,3 +1,8 @@
 .highlight {
   @apply text-secondary font-bold;
 }
+
+.highlight::before,
+.highlight::after {
+  content: '`';
+}

--- a/packages/ui/src/components/Highlight/Highlight.tsx
+++ b/packages/ui/src/components/Highlight/Highlight.tsx
@@ -2,7 +2,7 @@
 import styles from './Highlight.module.css';
 
 export const Highlight = ({ children }: HighlightProps) => (
-  <span className={styles.highlight}>`{children}`</span>
+  <span className={styles.highlight}>{children}</span>
 );
 
 export type HighlightProps = React.ComponentPropsWithoutRef<'span'>;


### PR DESCRIPTION
Technically it'll have the same effect but better.

Back stick won't be able to be selected and it'll improve the CMS editing experience (now I cannot change the content of a highlighted word)