### PR TITLE
fix: page transition bug

### DIFF
--- a/apps/website/src/pages/_app.page.tsx
+++ b/apps/website/src/pages/_app.page.tsx
@@ -105,7 +105,7 @@ const MyApp = ({ Component, pageProps, router }: AppProps) => {
         <LazyMotion features={domAnimation} strict>
           <AppContextProvider>
             <MenuBar />
-            <AnimatePresence>
+            <AnimatePresence exitBeforeEnter>
               <m.main
                 className="grid-container"
                 animate="enter"


### PR DESCRIPTION
This property enforces the page transition animation finishes before starts the entry animation