### PR TITLE
Add SEO

### DIFF
--- a/apps/website-remix/app/routes/$locale.tsx
+++ b/apps/website-remix/app/routes/$locale.tsx
@@ -1,5 +1,6 @@
 import { AppContextProvider } from '$infrastructure/contexts/App';
 import { LocalizationProvider } from '$infrastructure/contexts/Localization';
+import { getLocales } from '$infrastructure/i18n/getLocales';
 import { MenuBar } from '$ui/MenuBar';
 import type { SupportedLanguages } from '@raulmelo/core';
 import type { LoaderArgs } from '@remix-run/node';
@@ -10,23 +11,9 @@ import { AnimatePresence, domAnimation, LazyMotion, m } from 'framer-motion';
 import invariant from 'tiny-invariant';
 
 export async function loader({ params }: LoaderArgs) {
-  invariant(typeof params.locale === 'string', 'lang is required');
+  invariant(typeof params.locale === `string`, `lang is required`);
 
-  const currentLocale = params.locale as SupportedLanguages;
-
-  let messages: Record<string, string> = {};
-
-  if (currentLocale === 'en') {
-    messages = (await import(
-      '$infrastructure/locales/en.json'
-    )) as unknown as Record<string, string>;
-  } else if (currentLocale === 'pt') {
-    messages = (await import(
-      '$infrastructure/locales/pt.json'
-    )) as unknown as Record<string, string>;
-  } else {
-    throw new Error('Locale not supported');
-  }
+  const messages = await getLocales(params.locale as SupportedLanguages);
 
   return json({
     locale: params.locale as SupportedLanguages,

--- a/apps/website-remix/app/routes/$locale/til/index.tsx
+++ b/apps/website-remix/app/routes/$locale/til/index.tsx
@@ -1,10 +1,11 @@
 import { useLocalization } from '$infrastructure/contexts/Localization';
+import { getLocales } from '$infrastructure/i18n/getLocales';
 import { getTilUrl } from '$infrastructure/utils/url';
 import { ContentTile } from '$ui/ContentTile';
-import type { AllSupportedLanguages } from '@raulmelo/core';
+import type { AllSupportedLanguages, SupportedLanguages } from '@raulmelo/core';
 import { domains } from '@raulmelo/core';
 import type { ITilsApiResponse } from '@raulmelo/core/dist/types/domains/posts/queryTils/types';
-import type { LoaderArgs } from '@remix-run/node';
+import type { LoaderArgs, MetaFunction } from '@remix-run/node';
 import { json } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
 import classNames from 'classnames';
@@ -13,6 +14,15 @@ import invariant from 'tiny-invariant';
 
 type LoaderData = {
   tils: ITilsApiResponse;
+  messages: Record<string, string>;
+};
+
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  const { messages } = data;
+  return {
+    title: `Raul Melo - ${messages[`tilHome.title`]}`,
+    description: messages[`tilHome.title`],
+  };
 };
 
 export async function loader({ params }: LoaderArgs) {
@@ -24,6 +34,7 @@ export async function loader({ params }: LoaderArgs) {
 
   return json<LoaderData>({
     tils,
+    messages: await getLocales(params.locale as SupportedLanguages),
   });
 }
 
@@ -35,11 +46,6 @@ export default function TilsHome() {
 
   return (
     <>
-      {/* <NextSeo
-        title={formatMessage({ id: 'tilHome.title' })}
-        description={formatMessage({ id: 'tilHome.subtitle' })}
-      /> */}
-
       <header className={baseColClass}>
         <h1 className="text-3xl font-extrabold md:text-4xl">
           <FormattedMessage id="tilHome.title" />


### PR DESCRIPTION
## Description

On Next.js I had the `next-seo` package and implement SEO for almost all pages.

Here I need to implement this but using Remix strategy.

## TODO

- [ ] /
- [ ] /blog
- [ ] /blog/$slug
- [ ] /til
- [ ] /til/$slug
- [ ] /search
- [ ] /uses