### PR TITLE
Refactor core

### DIFF
--- a/apps/website-astro/astro.config.mjs
+++ b/apps/website-astro/astro.config.mjs
@@ -1,48 +1,48 @@
-import { defineConfig } from 'astro/config';
+import image from '@astrojs/image';
+import prefetch from '@astrojs/prefetch';
+import react from '@astrojs/react';
+import sitemap from '@astrojs/sitemap';
 import tailwind from '@astrojs/tailwind';
 import vercel from '@astrojs/vercel/serverless';
-import react from '@astrojs/react';
-import image from '@astrojs/image';
-import sitemap from '@astrojs/sitemap';
+import { defineConfig } from 'astro/config';
 import robotsTxt from 'astro-robots-txt';
-import prefetch from '@astrojs/prefetch';
 
 export default defineConfig({
-  site: 'https://raulmelo.dev',
+  site: `https://raulmelo.dev`,
   integrations: [
     tailwind(),
     react(),
     image({
-      serviceEntryPoint: '@astrojs/image/sharp',
+      serviceEntryPoint: `@astrojs/image/sharp`,
     }),
     sitemap({
       filter: (page) =>
-        !page.url.includes('/404') && !page.url.includes('/search'),
+        !page.url.includes(`/404`) && !page.url.includes(`/search`),
       i18n: {
-        defaultLocale: 'en',
+        defaultLocale: `en`,
         locales: {
-          en: 'en-UK',
-          pt: 'pt-BR',
+          en: `en-UK`,
+          pt: `pt-BR`,
         },
       },
     }),
     robotsTxt({
       policy: [
         {
-          userAgent: '*',
-          allow: '/',
-          disallow: ['/search', '/404'],
+          userAgent: `*`,
+          allow: `/`,
+          disallow: [`/search`, `/404`],
         },
       ],
     }),
     prefetch(),
   ],
-  output: 'server',
+  output: `server`,
   adapter: vercel({}),
   vite: {
     ssr: {
-      external: ['@raulmelo/core', '@raulmelo/ui', '@formatjs/intl'],
-      noExternal: ['@raulmelo/styles'],
+      external: [`@raulmelo/core`, `@raulmelo/ui`, `@formatjs/intl`],
+      noExternal: [`@raulmelo/styles`],
     },
   },
 });

--- a/apps/website-astro/middleware.ts
+++ b/apps/website-astro/middleware.ts
@@ -1,5 +1,5 @@
 import { match } from '@formatjs/intl-localematcher';
-import { type SupportedLanguages } from '@raulmelo/core/config';
+import type { SupportedLanguages } from '@raulmelo/core/config';
 import Negotiator from 'negotiator';
 
 export default function middleware(request: Request) {

--- a/apps/website-astro/middleware.ts
+++ b/apps/website-astro/middleware.ts
@@ -65,5 +65,6 @@ function normalizePathname(pathname: string) {
 }
 
 export const config = {
-  matcher: [`/((?!api|favicon.ico|assets|_astro|_image|build|@fs|@vite).*)`],
+  // eslint-disable-next-line @typescript-eslint/quotes
+  matcher: ['/((?!api|favicon.ico|assets|_astro|_image|build|@fs|@vite).*)'],
 };

--- a/apps/website-astro/middleware.ts
+++ b/apps/website-astro/middleware.ts
@@ -1,5 +1,5 @@
 import { match } from '@formatjs/intl-localematcher';
-import { SupportedLanguages } from '@raulmelo/core';
+import { type SupportedLanguages } from '@raulmelo/core/config';
 import Negotiator from 'negotiator';
 
 export default function middleware(request: Request) {
@@ -16,7 +16,7 @@ export default function middleware(request: Request) {
 
   if (pathnameIsMissingLocale) {
     const locale = getLanguageFromAcceptLanguage(
-      request.headers.get('accept-language') || '',
+      request.headers.get(`accept-language`) || ``,
     );
 
     const normalizedPathname = normalizePathname(`/${locale}/${url.pathname}`);
@@ -27,7 +27,7 @@ export default function middleware(request: Request) {
   }
 }
 
-const passThroughRoutes = ['/cv', '/admin'];
+const passThroughRoutes = [`/cv`, `/admin`];
 
 function skipMiddleware(url: string) {
   let shouldSkip = false;
@@ -43,8 +43,8 @@ function skipMiddleware(url: string) {
   return shouldSkip;
 }
 
-export const supportedLocales = ['en', 'pt'];
-const defaultLocale = 'en';
+export const supportedLocales = [`en`, `pt`];
+const defaultLocale = `en`;
 
 export function getLanguageFromAcceptLanguage(acceptLanguageHeader: string) {
   const languages = new Negotiator({
@@ -61,9 +61,9 @@ export function getLanguageFromAcceptLanguage(acceptLanguageHeader: string) {
 }
 
 function normalizePathname(pathname: string) {
-  return pathname.replaceAll('//', '/');
+  return pathname.replaceAll(`//`, `/`);
 }
 
 export const config = {
-  matcher: ['/((?!api|favicon.ico|assets|_astro|_image|build|@fs|@vite).*)'],
+  matcher: [`/((?!api|favicon.ico|assets|_astro|_image|build|@fs|@vite).*)`],
 };

--- a/apps/website-astro/src/infrastructure/i18n/getLangFromURL.ts
+++ b/apps/website-astro/src/infrastructure/i18n/getLangFromURL.ts
@@ -1,7 +1,7 @@
 import {
   type SupportedLanguages,
   supportedLanguagesSchema,
-} from '@raulmelo/core';
+} from '@raulmelo/core/config';
 
 export function getLangFromURL(url: string): null | SupportedLanguages {
   const pathname = new URL(url).pathname;

--- a/apps/website-astro/src/infrastructure/i18n/getLanguageFromAcceptLanguage.server.ts
+++ b/apps/website-astro/src/infrastructure/i18n/getLanguageFromAcceptLanguage.server.ts
@@ -1,5 +1,5 @@
 import { match } from '@formatjs/intl-localematcher';
-import { type SupportedLanguages } from '@raulmelo/core';
+import { type SupportedLanguages } from '@raulmelo/core/config';
 import Negotiator from 'negotiator';
 
 export const supportedLocales = [`en`, `pt`];

--- a/apps/website-astro/src/infrastructure/i18n/getServerSideLocales.server.ts
+++ b/apps/website-astro/src/infrastructure/i18n/getServerSideLocales.server.ts
@@ -2,7 +2,7 @@ import { createIntl, createIntlCache, type IntlShape } from '@formatjs/intl';
 import {
   type SupportedLanguages,
   supportedLanguagesSchema,
-} from '@raulmelo/core';
+} from '@raulmelo/core/config';
 import flat from 'flat';
 
 import enLocales from './locales/en.json';

--- a/apps/website-astro/src/infrastructure/sanity/schemas/customFields/imageSliderField.tsx
+++ b/apps/website-astro/src/infrastructure/sanity/schemas/customFields/imageSliderField.tsx
@@ -1,5 +1,8 @@
-import { utils } from '@raulmelo/core';
-import { type SanityImageSource } from '@raulmelo/core/dist/types/utils/image';
+import {
+  imgUrlFor,
+  isEmpty,
+  type SanityImageSource,
+} from '@raulmelo/core/utils';
 import { ImageSlider, ViewCarouselIcon } from '@raulmelo/ui';
 
 export const imageSliderField = {
@@ -29,7 +32,7 @@ export const imageSliderField = {
   ],
   components: {
     preview: ({ images }: SanityImageSliderProps) => {
-      if (images === undefined || utils.isEmpty(images)) {
+      if (images === undefined || isEmpty(images)) {
         return null;
       }
 
@@ -65,7 +68,7 @@ export const imageSliderField = {
 
       function prepareImages(sanityImage: SanityImageSliderImage) {
         const { image, ...props } = sanityImage;
-        const remoteImage = utils.imgUrlFor(image);
+        const remoteImage = imgUrlFor(image);
 
         return {
           src: remoteImage.url(),

--- a/apps/website-astro/src/infrastructure/utils/seo.ts
+++ b/apps/website-astro/src/infrastructure/utils/seo.ts
@@ -1,4 +1,4 @@
-import { type QuerySiteDataReturnType } from '@raulmelo/core/dist/types/domains/siteData';
+import { type QuerySiteDataReturnType } from '@raulmelo/core/domains';
 
 type Social = QuerySiteDataReturnType[`socials`][0];
 

--- a/apps/website-astro/src/infrastructure/utils/url.ts
+++ b/apps/website-astro/src/infrastructure/utils/url.ts
@@ -1,4 +1,4 @@
-import { type SupportedLanguages } from '@raulmelo/core';
+import { type SupportedLanguages } from '@raulmelo/core/config';
 
 /**
  * TODO: Move those functions to core/domains/*

--- a/apps/website-astro/src/pages/[lang]/blog/[slug].astro
+++ b/apps/website-astro/src/pages/[lang]/blog/[slug].astro
@@ -1,5 +1,7 @@
 ---
-import { domains, type SupportedLanguages,utils } from '@raulmelo/core';
+import { type SupportedLanguages } from '@raulmelo/core/config';
+import { queryPostBySlug, queryPosts } from '@raulmelo/core/domains';
+import { getEstimatedReadingTime, isEmpty, isNil } from '@raulmelo/core/utils';
 import { DotDivider, ProseContainer } from '@raulmelo/ui';
 
 import { getIntl } from '@/infrastructure/i18n/getServerSideLocales.server';
@@ -19,7 +21,7 @@ const { lang, slug } = Astro.params as {
 };
 
 export async function getStaticPaths() {
-  const posts = await domains.posts.queryPosts(`all`);
+  const posts = await queryPosts(`all`);
 
   return posts.map((post) => ({
     params: {
@@ -31,17 +33,15 @@ export async function getStaticPaths() {
 
 export const prerender = true;
 
-const post = await domains.posts.queryPostBySlug(slug);
+const post = await queryPostBySlug(slug);
 
-if (utils.isNil(post) || utils.isEmpty(post)) {
+if (isNil(post) || isEmpty(post)) {
   return {
     notFound: true,
   };
 }
 
-const estimatedReadingTime = utils.content.getEstimatedReadingTime(
-  post.content,
-);
+const estimatedReadingTime = getEstimatedReadingTime(post.content);
 
 const intl = getIntl(lang);
 ---

--- a/apps/website-astro/src/pages/[lang]/blog/index.astro
+++ b/apps/website-astro/src/pages/[lang]/blog/index.astro
@@ -1,5 +1,5 @@
 ---
-import { domains, type SupportedLanguages } from '@raulmelo/core';
+import { queryPosts,type SupportedLanguages } from '@raulmelo/core/domains';
 
 import { languageGetStaticPaths } from '@/infrastructure/getStaticPaths';
 import { getIntl } from '@/infrastructure/i18n/getServerSideLocales.server';
@@ -11,7 +11,7 @@ export const getStaticPaths = languageGetStaticPaths;
 
 const { lang } = Astro.params as { lang: SupportedLanguages };
 
-const posts = await domains.posts.queryPosts(lang as SupportedLanguages);
+const posts = await queryPosts(lang as SupportedLanguages);
 
 const intl = getIntl(lang);
 ---

--- a/apps/website-astro/src/pages/[lang]/index.astro
+++ b/apps/website-astro/src/pages/[lang]/index.astro
@@ -1,9 +1,9 @@
 ---
 import {
-  domains,
   type SupportedLanguages,
   supportedLanguagesSchema,
-} from '@raulmelo/core';
+} from '@raulmelo/core/config';
+import { queryPostsAndTils, querySiteData } from '@raulmelo/core/domains';
 
 import { languageGetStaticPaths } from '@/infrastructure/getStaticPaths';
 import { getIntl } from '@/infrastructure/i18n/getServerSideLocales.server';
@@ -34,8 +34,8 @@ if (!success) {
 
 const NUMBER_OF_POSTS = 2;
 const [siteData, { posts, tils }] = await Promise.all([
-  domains.siteData.querySiteData(),
-  domains.posts.queryPostsAndTils(lang, NUMBER_OF_POSTS),
+  querySiteData(),
+  queryPostsAndTils(lang, NUMBER_OF_POSTS),
 ]);
 
 const intl = getIntl(lang);

--- a/apps/website-astro/src/pages/[lang]/search.astro
+++ b/apps/website-astro/src/pages/[lang]/search.astro
@@ -1,7 +1,7 @@
 ---
 import '@/ui/screens/search/Search.css';
 
-import { type SupportedLanguages } from '@raulmelo/core';
+import { type SupportedLanguages } from '@raulmelo/core/config';
 import { renderToString } from 'react-dom/server';
 import { getServerState } from 'react-instantsearch-hooks-server';
 

--- a/apps/website-astro/src/pages/[lang]/til/[slug].astro
+++ b/apps/website-astro/src/pages/[lang]/til/[slug].astro
@@ -1,5 +1,7 @@
 ---
-import { domains, type SupportedLanguages,utils } from '@raulmelo/core';
+import { type SupportedLanguages } from '@raulmelo/core/config';
+import { queryTilBySlug, queryTils } from '@raulmelo/core/domains';
+import { getEstimatedReadingTime, isEmpty, isNil } from '@raulmelo/core/utils';
 import { ProseContainer } from '@raulmelo/ui';
 
 import { getIntl } from '@/infrastructure/i18n/getServerSideLocales.server';
@@ -17,7 +19,7 @@ const { lang, slug } = Astro.params as {
 };
 
 export async function getStaticPaths() {
-  const tils = await domains.posts.queryTils(`all`);
+  const tils = await queryTils(`all`);
 
   return tils.map((til) => ({
     params: {
@@ -29,14 +31,14 @@ export async function getStaticPaths() {
 
 export const prerender = true;
 
-const til = await domains.posts.queryTilBySlug(slug);
+const til = await queryTilBySlug(slug);
 
 // https://github.com/vercel/next.js/issues/16681#issuecomment-792314687
-if (utils.isNil(til) || utils.isEmpty(til)) {
+if (isNil(til) || isEmpty(til)) {
   return Astro.redirect(`/404`);
 }
 
-const estimatedReadingTime = utils.content.getEstimatedReadingTime(til.content);
+const estimatedReadingTime = getEstimatedReadingTime(til.content);
 
 const intl = getIntl(lang);
 ---

--- a/apps/website-astro/src/pages/[lang]/til/index.astro
+++ b/apps/website-astro/src/pages/[lang]/til/index.astro
@@ -1,5 +1,6 @@
 ---
-import { domains, type SupportedLanguages } from '@raulmelo/core';
+import { type SupportedLanguages } from '@raulmelo/core/config';
+import { queryTils } from '@raulmelo/core/domains';
 import classNames from 'classnames';
 
 import { languageGetStaticPaths } from '@/infrastructure/getStaticPaths';
@@ -12,7 +13,7 @@ export const getStaticPaths = languageGetStaticPaths;
 
 const { lang } = Astro.params as { lang: SupportedLanguages };
 
-const tils = await domains.posts.queryTils(lang as SupportedLanguages);
+const tils = await queryTils(lang as SupportedLanguages);
 
 const intl = getIntl(lang);
 

--- a/apps/website-astro/src/pages/[lang]/uses.astro
+++ b/apps/website-astro/src/pages/[lang]/uses.astro
@@ -1,5 +1,7 @@
 ---
-import { domains, type SupportedLanguages,utils } from '@raulmelo/core';
+import { type SupportedLanguages } from '@raulmelo/core/config';
+import { getUses } from '@raulmelo/core/domains';
+import { isEmpty, isNil } from '@raulmelo/core/utils';
 import { ProseContainer } from '@raulmelo/ui';
 
 import { languageGetStaticPaths } from '@/infrastructure/getStaticPaths';
@@ -17,9 +19,9 @@ const { lang } = Astro.params as {
   lang: SupportedLanguages;
 };
 
-const uses = await domains.uses.getUses(lang as SupportedLanguages);
+const uses = await getUses(lang as SupportedLanguages);
 
-if (utils.isNil(uses) || utils.isEmpty(uses)) {
+if (isNil(uses) || isEmpty(uses)) {
   return Astro.redirect(`/404`);
 }
 

--- a/apps/website-astro/src/ui/DefaultSEO.astro
+++ b/apps/website-astro/src/ui/DefaultSEO.astro
@@ -1,6 +1,7 @@
 ---
-import { domains, type SupportedLanguages } from '@raulmelo/core';
-import { type Link, type Meta,type Props as SeoProps, SEO } from 'astro-seo';
+import { type SupportedLanguages } from '@raulmelo/core/config';
+import { querySiteData } from '@raulmelo/core/domains';
+import { type Link, type Meta, type Props as SeoProps, SEO } from 'astro-seo';
 
 export type Props = {
   lang: SupportedLanguages;
@@ -30,7 +31,7 @@ const {
   noindex = false,
 } = Astro.props;
 
-const siteData = await domains.siteData.querySiteData();
+const siteData = await querySiteData();
 
 const langSeo = siteData.defaultSeo[lang] as NonNullable<
   typeof siteData.defaultSeo[`en` | `pt`]

--- a/apps/website-astro/src/ui/LanguageSwitch/LanguageSwitch.tsx
+++ b/apps/website-astro/src/ui/LanguageSwitch/LanguageSwitch.tsx
@@ -1,5 +1,5 @@
 import { Popover } from '@headlessui/react';
-import { type SupportedLanguages } from '@raulmelo/core';
+import { type SupportedLanguages } from '@raulmelo/core/config';
 import { GlobeIcon } from '@raulmelo/ui';
 import { useState } from 'react';
 import { usePopper } from 'react-popper';

--- a/apps/website-astro/src/ui/MenuBar.tsx
+++ b/apps/website-astro/src/ui/MenuBar.tsx
@@ -1,4 +1,4 @@
-import { type SupportedLanguages } from '@raulmelo/core';
+import { type SupportedLanguages } from '@raulmelo/core/config';
 import { CloseIcon, MenuIcon } from '@raulmelo/ui';
 import { domAnimation, LazyMotion } from 'framer-motion';
 

--- a/apps/website-astro/src/ui/PortableText/CodeBlock.astro
+++ b/apps/website-astro/src/ui/PortableText/CodeBlock.astro
@@ -1,5 +1,5 @@
 ---
-import { type SupportedLanguages } from '@raulmelo/core';
+import { type SupportedLanguages } from '@raulmelo/core/config';
 import { CodeBlock } from '@raulmelo/ui';
 
 import { getIntl } from '@/infrastructure/i18n/getServerSideLocales.server';

--- a/apps/website-astro/src/ui/PortableText/ImageSlider.astro
+++ b/apps/website-astro/src/ui/PortableText/ImageSlider.astro
@@ -1,5 +1,10 @@
 ---
-import { utils } from '@raulmelo/core';
+import {
+  getImageDimensionsFromSanityImageUrl,
+  imgUrlFor,
+  isEmpty,
+  isNil,
+} from '@raulmelo/core/utils';
 import { ImageSlider } from '@raulmelo/ui';
 
 type ImageNode = {
@@ -20,13 +25,13 @@ type Props = {
 
 const { images } = Astro.props.node;
 
-const isImageEmpty = utils.isNil(images) || utils.isEmpty(images);
+const isImageEmpty = isNil(images) || isEmpty(images);
 
 const adaptedImages = images.map((img) => {
   const { alt, caption, image } = img;
-  const src = utils.imgUrlFor(image).url();
+  const src = imgUrlFor(image).url();
 
-  const imgDimensions = utils.getImageDimensionsFromSanityImageUrl(src);
+  const imgDimensions = getImageDimensionsFromSanityImageUrl(src);
 
   return {
     alt,

--- a/apps/website-astro/src/ui/PortableText/InternalLink.astro
+++ b/apps/website-astro/src/ui/PortableText/InternalLink.astro
@@ -1,5 +1,5 @@
 ---
-import { type SupportedLanguages } from '@raulmelo/core';
+import { type SupportedLanguages } from '@raulmelo/core/config';
 
 import { getPostUrl, getTilUrl } from '@/infrastructure/utils/url';
 

--- a/apps/website-astro/src/ui/PostBasic.astro
+++ b/apps/website-astro/src/ui/PostBasic.astro
@@ -1,5 +1,5 @@
 ---
-import { type SupportedLanguages } from '@raulmelo/core';
+import { type SupportedLanguages } from '@raulmelo/core/config';
 import classNames from 'classnames';
 
 import { getIntl } from '@/infrastructure/i18n/getServerSideLocales.server';

--- a/apps/website-astro/src/ui/SideMenu/SideMenu.tsx
+++ b/apps/website-astro/src/ui/SideMenu/SideMenu.tsx
@@ -1,5 +1,5 @@
 import { Disclosure } from '@headlessui/react';
-import { type SupportedLanguages } from '@raulmelo/core';
+import { type SupportedLanguages } from '@raulmelo/core/config';
 import { ExternalLinkIcon } from '@raulmelo/ui';
 import classNames from 'classnames';
 import { m, useAnimation } from 'framer-motion';

--- a/apps/website-astro/src/ui/layouts/Layout.astro
+++ b/apps/website-astro/src/ui/layouts/Layout.astro
@@ -11,7 +11,7 @@ import '@raulmelo/ui/styles/prism.css';
 import '@raulmelo/ui/styles/style.css';
 import '@raulmelo/styles/lib/styles.css';
 
-import { type SupportedLanguages } from '@raulmelo/core';
+import { type SupportedLanguages } from '@raulmelo/core/config';
 
 import DefaultSEO, { type Props as SeoProps } from '@/ui/DefaultSEO.astro';
 import Logo from '@/ui/Logo.astro';

--- a/apps/website-astro/src/ui/screens/blog/FeaturedImage.astro
+++ b/apps/website-astro/src/ui/screens/blog/FeaturedImage.astro
@@ -1,15 +1,14 @@
 ---
 import { Picture } from '@astrojs/image/components';
-import { type domains, type SupportedLanguages } from '@raulmelo/core';
+import { type SupportedLanguages } from '@raulmelo/core/config';
+import { type QueryPostBySlugReturnType } from '@raulmelo/core/domains';
 
 import { getIntl } from '@/infrastructure/i18n/getServerSideLocales.server';
 
-type Post = Awaited<ReturnType<typeof domains.posts.queryPostBySlug>>;
-
 type Props = {
   lang: SupportedLanguages;
-  featuredImage: NonNullable<Post[`featuredImage`]>;
-  unsplash?: Post[`unsplash`];
+  featuredImage: NonNullable<QueryPostBySlugReturnType[`featuredImage`]>;
+  unsplash?: QueryPostBySlugReturnType[`unsplash`];
 };
 
 const { lang, featuredImage, unsplash } = Astro.props;

--- a/apps/website-astro/src/ui/screens/blog/Posts.tsx
+++ b/apps/website-astro/src/ui/screens/blog/Posts.tsx
@@ -1,5 +1,5 @@
-import { type SupportedLanguages } from '@raulmelo/core';
-import { type QueryPostsAndTilsReturnType } from '@raulmelo/core/dist/types/domains/posts/queryPostsAndTils';
+import { type SupportedLanguages } from '@raulmelo/core/config';
+import { type QueryPostsAndTilsReturnType } from '@raulmelo/core/domains';
 import { AnimatePresence, domAnimation, LazyMotion, m } from 'framer-motion';
 
 import { getIntl } from '@/infrastructure/i18n/getServerSideLocales.server';

--- a/apps/website-astro/src/ui/screens/blog/types.ts
+++ b/apps/website-astro/src/ui/screens/blog/types.ts
@@ -1,5 +1,3 @@
-import { type domains } from '@raulmelo/core';
+import { type QueryPostBySlugReturnType } from '@raulmelo/core/domains';
 
-export type PostBySlug = Awaited<
-  ReturnType<typeof domains.posts.queryPostBySlug>
->;
+export type PostBySlug = QueryPostBySlugReturnType;

--- a/apps/website-astro/src/ui/screens/home/AuthorPresentation.astro
+++ b/apps/website-astro/src/ui/screens/home/AuthorPresentation.astro
@@ -5,8 +5,8 @@ export type Props = {
 };
 
 import { Image } from '@astrojs/image/components';
-import { type SupportedLanguages } from '@raulmelo/core';
-import { type QuerySiteDataReturnType } from '@raulmelo/core/dist/types/domains/siteData';
+import { type SupportedLanguages } from '@raulmelo/core/config';
+import { type QuerySiteDataReturnType } from '@raulmelo/core/domains';
 
 import { getIntl } from '@/infrastructure/i18n/getServerSideLocales.server';
 import { getSocial } from '@/infrastructure/utils/seo';

--- a/apps/website-astro/src/ui/screens/home/PostSection.astro
+++ b/apps/website-astro/src/ui/screens/home/PostSection.astro
@@ -9,7 +9,7 @@ export type Props = {
   posts: PostBasicProps[];
 };
 
-import { type SupportedLanguages } from '@raulmelo/core';
+import { type SupportedLanguages } from '@raulmelo/core/config';
 
 import ArrowRightIcon from '@/ui/Icons/ArrowRight.astro';
 import PostBasic, { type Props as PostBasicProps } from '@/ui/PostBasic.astro';

--- a/apps/website-astro/src/ui/screens/search/Filters.tsx
+++ b/apps/website-astro/src/ui/screens/search/Filters.tsx
@@ -1,4 +1,5 @@
-import { type SupportedLanguages, utils } from '@raulmelo/core';
+import { type SupportedLanguages } from '@raulmelo/core/config';
+import { isEmpty } from '@raulmelo/core/utils';
 import classNames from 'classnames';
 import { useRefinementList } from 'react-instantsearch-hooks-web';
 
@@ -76,7 +77,7 @@ function TagsRefinement({ title }: { title: string }) {
 }
 
 function GenericRefinement({ title, refine, items, renderLabelText }: any) {
-  return utils.isEmpty(items) ? null : (
+  return isEmpty(items) ? null : (
     <div className="search__refinementWrapper">
       <h3 className="text-lg font-bold">{title}</h3>
 

--- a/apps/website-astro/src/ui/screens/search/Hits.tsx
+++ b/apps/website-astro/src/ui/screens/search/Hits.tsx
@@ -1,4 +1,4 @@
-import { type SupportedLanguages } from '@raulmelo/core';
+import { type SupportedLanguages } from '@raulmelo/core/config';
 import classNames from 'classnames';
 import { Hits as HitsComp } from 'react-instantsearch-hooks-web';
 

--- a/apps/website-astro/src/ui/screens/search/Search.tsx
+++ b/apps/website-astro/src/ui/screens/search/Search.tsx
@@ -1,4 +1,4 @@
-import { type SupportedLanguages } from '@raulmelo/core';
+import { type SupportedLanguages } from '@raulmelo/core/config';
 import { InstantSearch } from 'react-instantsearch-hooks-web';
 
 import { Filters } from './Filters';

--- a/apps/website-astro/src/ui/screens/search/SearchSSR.tsx
+++ b/apps/website-astro/src/ui/screens/search/SearchSSR.tsx
@@ -1,4 +1,4 @@
-import { type SupportedLanguages } from '@raulmelo/core';
+import { type SupportedLanguages } from '@raulmelo/core/config';
 import {
   type InstantSearchServerState,
   InstantSearchSSRProvider,

--- a/apps/website-astro/src/ui/screens/search/types.ts
+++ b/apps/website-astro/src/ui/screens/search/types.ts
@@ -1,4 +1,4 @@
-import { type AlgoliaObject } from '@raulmelo/core/dist/types/domains/algolia';
+import { type AlgoliaObject } from '@raulmelo/core/domains';
 
 export type HitAlgolia = AlgoliaObject;
 

--- a/apps/website-astro/src/ui/screens/tils/Tils.tsx
+++ b/apps/website-astro/src/ui/screens/tils/Tils.tsx
@@ -1,14 +1,13 @@
-import { type domains, type SupportedLanguages } from '@raulmelo/core';
+import { type SupportedLanguages } from '@raulmelo/core/config';
+import { type QueryTilsReturnType } from '@raulmelo/core/domains';
 import { domAnimation, LazyMotion } from 'framer-motion';
 
 import { getIntl } from '@/infrastructure/i18n/getServerSideLocales.server';
 import { getTilUrl } from '@/infrastructure/utils/url';
 import { ContentTile } from '@/ui/ContentTile';
 
-type Tils = Awaited<ReturnType<typeof domains.posts.queryTils>>;
-
 type TilsProps = {
-  tils: Tils;
+  tils: QueryTilsReturnType;
   lang: SupportedLanguages;
 };
 

--- a/apps/website-remix/app/infrastructure/config/sanity/schemas/customFields/imageSliderField.tsx
+++ b/apps/website-remix/app/infrastructure/config/sanity/schemas/customFields/imageSliderField.tsx
@@ -1,5 +1,5 @@
-import { utils } from '@raulmelo/core';
-import type { SanityImageSource } from '@raulmelo/core/dist/types/utils/image';
+import type { SanityImageSource } from '@raulmelo/core/utils';
+import { imgUrlFor, isEmpty } from '@raulmelo/core/utils';
 import { ImageSlider, ViewCarouselIcon } from '@raulmelo/ui';
 
 export const imageSliderField = {
@@ -29,7 +29,7 @@ export const imageSliderField = {
   ],
   components: {
     preview: ({ images }: SanityImageSliderProps) => {
-      if (images === undefined || utils.isEmpty(images)) {
+      if (images === undefined || isEmpty(images)) {
         return null;
       }
 
@@ -65,7 +65,7 @@ export const imageSliderField = {
 
       function prepareImages(sanityImage: SanityImageSliderImage) {
         const { image, ...props } = sanityImage;
-        const remoteImage = utils.imgUrlFor(image);
+        const remoteImage = imgUrlFor(image);
 
         return {
           src: remoteImage.url(),

--- a/apps/website-remix/app/infrastructure/contexts/Localization.tsx
+++ b/apps/website-remix/app/infrastructure/contexts/Localization.tsx
@@ -1,5 +1,5 @@
 import { useAppLocation } from '$infrastructure/hooks/useAppLocation';
-import type { SupportedLanguages } from '@raulmelo/core';
+import type { SupportedLanguages } from '@raulmelo/core/config';
 import { useNavigate } from '@remix-run/react';
 import { createContext, useContext } from 'react';
 import type { IntlShape } from 'react-intl';

--- a/apps/website-remix/app/infrastructure/hooks/useThemeHandler.ts
+++ b/apps/website-remix/app/infrastructure/hooks/useThemeHandler.ts
@@ -1,12 +1,12 @@
-import type { AppTheme} from '@raulmelo/core';
-import { utils } from '@raulmelo/core';
+import type { AppTheme } from '@raulmelo/core/config';
+import { isBrowserApiAvailable } from '@raulmelo/core/utils';
 import { useMachine } from '@xstate/react';
 import { createMachine } from 'xstate';
 
 /* TODO: find a way to consume this value from a single source of truth */
 const colorMap = {
-  light: '#FFFFFF',
-  dark: 'rgb(15, 23, 42)',
+  light: `#FFFFFF`,
+  dark: `rgb(15, 23, 42)`,
 };
 
 function removeThemeClass(theme: AppTheme) {
@@ -20,14 +20,14 @@ function setThemeClass(theme: AppTheme) {
     document.documentElement.classList.add(theme);
     window.__theme = theme;
     document
-      .querySelector('meta[name="theme-color"]')
-      ?.setAttribute('content', colorMap[theme]);
+      .querySelector(`meta[name="theme-color"]`)
+      ?.setAttribute(`content`, colorMap[theme]);
   };
 }
 
 function saveThemeOnLocalStorage(theme: AppTheme) {
   return () => {
-    localStorage.setItem('theme', theme);
+    localStorage.setItem(`theme`, theme);
   };
 }
 
@@ -35,41 +35,42 @@ const themeMachine = createMachine(
   {
     predictableActionArguments: true,
     preserveActionOrder: true,
+    // eslint-disable-next-line quotes
     tsTypes: {} as import('./useThemeHandler.typegen').Typegen0,
-    initial: 'unset',
+    initial: `unset`,
     states: {
       unset: {
         always: [
           {
-            target: 'light',
-            cond: 'isLight',
+            target: `light`,
+            cond: `isLight`,
           },
           {
-            target: 'dark',
+            target: `dark`,
           },
         ],
       },
       light: {
         entry: [
-          setThemeClass('light'),
-          saveThemeOnLocalStorage('light'),
-          removeThemeClass('dark'),
+          setThemeClass(`light`),
+          saveThemeOnLocalStorage(`light`),
+          removeThemeClass(`dark`),
         ],
         on: {
           TOGGLE: {
-            target: 'dark',
+            target: `dark`,
           },
         },
       },
       dark: {
         entry: [
-          setThemeClass('dark'),
-          saveThemeOnLocalStorage('dark'),
-          removeThemeClass('light'),
+          setThemeClass(`dark`),
+          saveThemeOnLocalStorage(`dark`),
+          removeThemeClass(`light`),
         ],
         on: {
           TOGGLE: {
-            target: 'light',
+            target: `light`,
           },
         },
       },
@@ -83,9 +84,9 @@ const themeMachine = createMachine(
          * Because NEXT will run this on node first, I have to check
          * if the window is defined before checking the __theme property.
          */
-        if (utils.isBrowserApiAvailable.window) {
+        if (isBrowserApiAvailable.window) {
           if (window.__theme) {
-            result = window.__theme === 'light';
+            result = window.__theme === `light`;
           }
         }
 
@@ -100,6 +101,6 @@ export function useThemeHandler() {
 
   return {
     currentTheme: state.value as AppTheme,
-    toggleTheme: () => send('TOGGLE'),
+    toggleTheme: () => send(`TOGGLE`),
   };
 }

--- a/apps/website-remix/app/infrastructure/i18n/getServerSideLocales.server.ts
+++ b/apps/website-remix/app/infrastructure/i18n/getServerSideLocales.server.ts
@@ -3,7 +3,7 @@ import { createIntl, createIntlCache } from '@formatjs/intl';
 import flat from 'flat';
 import enLocales from '$infrastructure/locales/en.json';
 import ptLocales from '$infrastructure/locales/pt.json';
-import type { SupportedLanguages } from '@raulmelo/core';
+import type { SupportedLanguages } from '@raulmelo/core/config';
 
 /**
  * Caches prevent memory leaks and improve performance by caching

--- a/apps/website-remix/app/infrastructure/utils/i18n.ts
+++ b/apps/website-remix/app/infrastructure/utils/i18n.ts
@@ -1,4 +1,4 @@
-import type { SupportedLanguages } from '@raulmelo/core';
+import type { SupportedLanguages } from '@raulmelo/core/config';
 import { createCookie } from '@remix-run/node';
 import type { Params } from '@remix-run/react';
 import acceptLanguage from 'accept-language-parser';

--- a/apps/website-remix/app/infrastructure/utils/url.ts
+++ b/apps/website-remix/app/infrastructure/utils/url.ts
@@ -1,9 +1,9 @@
-import type { SupportedLanguages } from '@raulmelo/core';
+import type { SupportedLanguages } from '@raulmelo/core/config';
 
 /**
  * TODO: Move those functions to core/domains/*
  */
-export function getPostUrl(
+export default function getPostUrl(
   postSlug: string,
   locale: SupportedLanguages,
 ): string {

--- a/apps/website-remix/app/root.tsx
+++ b/apps/website-remix/app/root.tsx
@@ -16,19 +16,19 @@ import type { PublicEnv } from '$infrastructure/config/publicAppConfig';
 import { getPublicEnvironmentVariables } from '$infrastructure/config/publicAppConfig';
 import type { StructuredDataFunction } from 'remix-utils';
 import { StructuredData } from 'remix-utils';
-import type { SiteData } from '@raulmelo/core/dist/types/domains/siteData';
-import type { SupportedLanguages } from '@raulmelo/core';
-import { domains } from '@raulmelo/core';
 import { getSEOTags } from '$infrastructure/utils/seo';
 import type { Organization, Person } from 'schema-dts';
 import { useEffect } from 'react';
 import { gtag } from '$infrastructure/utils/gtag.client';
 import { useAppLocation } from '$infrastructure/hooks/useAppLocation';
+import type { SupportedLanguages } from '@raulmelo/core/config';
+import type { QuerySiteDataReturnType } from '@raulmelo/core/domains';
+import { querySiteData } from '@raulmelo/core/domains';
 
 type LoaderData = {
   ENV: PublicEnv;
   locale: SupportedLanguages;
-  siteData: SiteData;
+  siteData: QuerySiteDataReturnType;
   pathname: string;
   origin: string;
   url: string;
@@ -141,7 +141,7 @@ export function links() {
 export async function loader({ params, request }: LoaderArgs) {
   const locale = (params.locale || `en`) as SupportedLanguages;
 
-  const siteData = await domains.siteData.querySiteData();
+  const siteData = await querySiteData();
 
   const url = new URL(request.url);
 

--- a/apps/website-remix/app/routes/($locale)/blog/$slug.tsx
+++ b/apps/website-remix/app/routes/($locale)/blog/$slug.tsx
@@ -1,9 +1,12 @@
 import { getSEOTags } from '$infrastructure/utils/seo';
 import { PortableTextPost } from '$ui/PortableTextPost';
 import { SeriesSection } from '$ui/screens/blog/SeriesSection';
-import { domains, utils } from '@raulmelo/core';
-import type { QueryPostBySlugReturnType } from '@raulmelo/core/dist/types/domains/posts/queryPostBySlug';
-import type { QuerySiteDataReturnType } from '@raulmelo/core/dist/types/domains/siteData/querySiteData';
+import type {
+  QueryPostBySlugReturnType,
+  QuerySiteDataReturnType,
+} from '@raulmelo/core/domains';
+import { queryPostBySlug, querySiteData } from '@raulmelo/core/domains';
+import { getEstimatedReadingTime, isEmpty, isNil } from '@raulmelo/core/utils';
 import { DotDivider } from '@raulmelo/ui';
 import type { LoaderArgs, MetaFunction, SerializeFrom } from '@remix-run/node';
 import { json } from '@remix-run/node';
@@ -101,17 +104,15 @@ export async function loader({ params, request }: LoaderArgs) {
   invariant(params.slug, `Slug is required`);
 
   const [post, siteData] = await Promise.all([
-    domains.posts.queryPostBySlug(params.slug),
-    domains.siteData.querySiteData(),
+    queryPostBySlug(params.slug),
+    querySiteData(),
   ]);
 
-  if (utils.isNil(post) || utils.isEmpty(post)) {
+  if (isNil(post) || isEmpty(post)) {
     throw new Response(`Not Found`, { status: 404 });
   }
 
-  const estimatedReadingTime = utils.content.getEstimatedReadingTime(
-    post.content,
-  );
+  const estimatedReadingTime = getEstimatedReadingTime(post.content);
 
   return json<LoaderData>({
     post,

--- a/apps/website-remix/app/routes/($locale)/blog/index.tsx
+++ b/apps/website-remix/app/routes/($locale)/blog/index.tsx
@@ -4,8 +4,8 @@ import { getLocales } from '$infrastructure/i18n/getLocales.server';
 import { getParamLocaleOrDefault } from '$infrastructure/utils/i18n';
 import { getSEOTags } from '$infrastructure/utils/seo';
 import { Posts } from '$ui/screens/home/Posts';
-import { domains } from '@raulmelo/core';
-import type { IBlogPagePost } from '@raulmelo/core/dist/types/domains/posts';
+import type { QueryPostsReturnType } from '@raulmelo/core/domains';
+import { queryPosts } from '@raulmelo/core/domains';
 import type { LoaderArgs, MetaFunction } from '@remix-run/node';
 import { json } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
@@ -13,7 +13,7 @@ import { useLoaderData } from '@remix-run/react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 type LoaderData = {
-  posts: IBlogPagePost[];
+  posts: QueryPostsReturnType[];
   messages: FlatMessages;
 };
 
@@ -40,7 +40,7 @@ export async function loader({ params }: LoaderArgs) {
   const locale = getParamLocaleOrDefault(params);
 
   const [posts, messages] = await Promise.all([
-    domains.posts.queryPosts(locale),
+    queryPosts(locale),
     getLocales(locale),
   ]);
 

--- a/apps/website-remix/app/routes/($locale)/index.tsx
+++ b/apps/website-remix/app/routes/($locale)/index.tsx
@@ -2,26 +2,25 @@ import { useLocalization } from '$infrastructure/contexts/Localization';
 import { AuthorPresentation } from '$ui/screens/home/AuthorPresentation';
 import type { LoaderArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
-import invariant from 'tiny-invariant';
-import type { SupportedLanguages } from '@raulmelo/core';
-import { domains } from '@raulmelo/core';
 import { Link, useLoaderData } from '@remix-run/react';
-import type { ISiteData } from '@raulmelo/core/dist/types/domains/siteData';
 import { defineMessages } from 'react-intl';
-import type { IPostsAndTilsApi } from '@raulmelo/core/dist/types/domains/posts';
-import {
+import getPostUrl, {
   getPathnameWithLocale,
-  getPostUrl,
   getTilUrl,
 } from '$infrastructure/utils/url';
 import type { PostBasicProps } from '$ui/PostBasic';
 import { PostBasic } from '$ui/PostBasic';
 import { ArrowRightIcon } from '@raulmelo/ui';
 import { getParamLocaleOrDefault } from '$infrastructure/utils/i18n';
+import type {
+  QueryPostsAndTilsReturnType,
+  QuerySiteDataReturnType,
+} from '@raulmelo/core/domains';
+import { queryPostsAndTils, querySiteData } from '@raulmelo/core/domains';
 
 type LoaderData = {
-  siteData: ISiteData;
-} & IPostsAndTilsApi;
+  siteData: QuerySiteDataReturnType;
+} & QueryPostsAndTilsReturnType;
 
 const messages = defineMessages({
   postsTitle: {
@@ -43,8 +42,8 @@ export async function loader({ params }: LoaderArgs) {
 
   const NUMBER_OF_POSTS = 2;
   const [siteData, { posts, tils }] = await Promise.all([
-    domains.siteData.querySiteData(),
-    domains.posts.queryPostsAndTils(locale, NUMBER_OF_POSTS),
+    querySiteData(),
+    queryPostsAndTils(locale, NUMBER_OF_POSTS),
   ]);
 
   return json<LoaderData>({
@@ -63,7 +62,7 @@ export default function Index() {
       <AuthorPresentation siteData={siteData} />
       <PostSection
         title={formatMessage(messages.postsTitle)}
-        posts={posts.map((post) => ({
+        posts={posts.map((post: any) => ({
           ...post,
           publishedAt: post.publishedAt,
           tags: post.tags,
@@ -78,7 +77,7 @@ export default function Index() {
       <hr className="mb-8 col-span-full md:col-start-2 md:col-end-6 lg:col-start-3 lg:col-end-10" />
       <PostSection
         title={formatMessage(messages.tilsTitle)}
-        posts={tils.map((til) => ({
+        posts={tils.map((til: any) => ({
           ...til,
           url: getTilUrl(til.slug, locale),
         }))}

--- a/apps/website-remix/app/routes/($locale)/til/index.tsx
+++ b/apps/website-remix/app/routes/($locale)/til/index.tsx
@@ -4,9 +4,8 @@ import { getParamLocaleOrDefault } from '$infrastructure/utils/i18n';
 import { getSEOTags } from '$infrastructure/utils/seo';
 import { getTilUrl } from '$infrastructure/utils/url';
 import { ContentTile } from '$ui/ContentTile';
-import type { AllSupportedLanguages, SupportedLanguages } from '@raulmelo/core';
-import { domains } from '@raulmelo/core';
-import type { ITilsApiResponse } from '@raulmelo/core/dist/types/domains/posts/queryTils/types';
+import type { QueryTilsReturnType } from '@raulmelo/core/domains';
+import { queryTils } from '@raulmelo/core/domains';
 import type { LoaderArgs, MetaFunction } from '@remix-run/node';
 import { json } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
@@ -14,7 +13,7 @@ import classNames from 'classnames';
 import { FormattedMessage } from 'react-intl';
 
 type LoaderData = {
-  tils: ITilsApiResponse;
+  tils: QueryTilsReturnType;
   messages: Record<string, string>;
 };
 
@@ -31,7 +30,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 export async function loader({ params }: LoaderArgs) {
   const locale = getParamLocaleOrDefault(params);
 
-  const tils = await domains.posts.queryTils(locale);
+  const tils = await queryTils(locale);
 
   return json<LoaderData>({
     tils,

--- a/apps/website-remix/app/routes/($locale)/uses.tsx
+++ b/apps/website-remix/app/routes/($locale)/uses.tsx
@@ -2,9 +2,12 @@ import { useLocalization } from '$infrastructure/contexts/Localization';
 import { getParamLocaleOrDefault } from '$infrastructure/utils/i18n';
 import { getSEOTags } from '$infrastructure/utils/seo';
 import { PortableTextPost } from '$ui/PortableTextPost';
-import { domains, utils } from '@raulmelo/core';
-import type { ISiteData } from '@raulmelo/core/dist/types/domains/siteData';
-import type { IUsesApiResponse } from '@raulmelo/core/dist/types/domains/uses/getUses/types';
+import type {
+  GetUsesReturnType,
+  QuerySiteDataReturnType,
+} from '@raulmelo/core/domains';
+import { getUses, querySiteData } from '@raulmelo/core/domains';
+import { getEstimatedReadingTime } from '@raulmelo/core/utils';
 import type { LoaderArgs, MetaFunction, SerializeFrom } from '@remix-run/node';
 import { json } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
@@ -12,9 +15,9 @@ import type { StructuredDataFunction } from 'remix-utils';
 import type { BlogPosting } from 'schema-dts';
 
 type LoaderData = {
-  uses: IUsesApiResponse;
+  uses: GetUsesReturnType;
   estimatedReadingTime: number;
-  siteData: ISiteData;
+  siteData: QuerySiteDataReturnType;
   url: string;
 };
 
@@ -71,13 +74,11 @@ export async function loader({ params, request }: LoaderArgs) {
   const locale = getParamLocaleOrDefault(params);
 
   const [uses, siteData] = await Promise.all([
-    domains.uses.getUses(locale),
-    domains.siteData.querySiteData(),
+    getUses(locale),
+    querySiteData(),
   ]);
 
-  const estimatedReadingTime = utils.content.getEstimatedReadingTime(
-    uses.content,
-  );
+  const estimatedReadingTime = getEstimatedReadingTime(uses.content);
 
   return json<LoaderData>({
     uses,

--- a/apps/website-remix/app/routes/api/webhooks/update-algolia.ts
+++ b/apps/website-remix/app/routes/api/webhooks/update-algolia.ts
@@ -1,5 +1,5 @@
 import { appConfig } from '$infrastructure/config/index.server';
-import { domains } from '@raulmelo/core';
+import { queryAlgoliaData } from '@raulmelo/core/domains';
 import type { ActionArgs } from '@remix-run/node';
 import { json } from '@remix-run/node';
 import algolia from 'algoliasearch';
@@ -30,7 +30,7 @@ export async function action({ request }: ActionArgs) {
       throw new Error(`Unauthorized`);
     }
 
-    const algoliaData = await domains.algolia.queryAlgoliaData();
+    const algoliaData = await queryAlgoliaData();
 
     const index = client.initIndex(appConfig.search.indexName);
 

--- a/apps/website-remix/app/screens/search/components/Filters.tsx
+++ b/apps/website-remix/app/screens/search/components/Filters.tsx
@@ -1,5 +1,5 @@
-import type { SupportedLanguages } from '@raulmelo/core';
-import { utils } from '@raulmelo/core';
+import type { SupportedLanguages } from '@raulmelo/core/config';
+import { isEmpty } from '@raulmelo/core/utils';
 import classNames from 'classnames';
 
 import { useRefinementList } from 'react-instantsearch-hooks-web';
@@ -78,7 +78,7 @@ function TagsRefinement({ title }: { title: string }) {
 }
 
 function GenericRefinement({ title, refine, items, renderLabelText }: any) {
-  return utils.isEmpty(items) ? null : (
+  return isEmpty(items) ? null : (
     <div className="search__refinementWrapper">
       <h3 className="text-lg font-bold">{title}</h3>
 

--- a/apps/website-remix/app/screens/search/components/Hits.tsx
+++ b/apps/website-remix/app/screens/search/components/Hits.tsx
@@ -1,6 +1,6 @@
-import { getPostUrl, getTilUrl } from '$infrastructure/utils/url';
+import getPostUrl, { getTilUrl } from '$infrastructure/utils/url';
 import { PostBasic } from '$ui/PostBasic';
-import type { SupportedLanguages } from '@raulmelo/core';
+import type { SupportedLanguages } from '@raulmelo/core/config';
 import { Hits as HitsComp } from 'react-instantsearch-hooks-web';
 
 import type { HitAlgolia } from '../types';

--- a/apps/website-remix/app/screens/search/components/Search.tsx
+++ b/apps/website-remix/app/screens/search/components/Search.tsx
@@ -1,4 +1,4 @@
-import type { SupportedLanguages } from '@raulmelo/core';
+import type { SupportedLanguages } from '@raulmelo/core/config';
 import { InstantSearch } from 'react-instantsearch-hooks-web';
 
 import { searchClient } from '../searchClient';

--- a/apps/website-remix/app/ui/PortableTextPost/components/ImageAdapter.tsx
+++ b/apps/website-remix/app/ui/PortableTextPost/components/ImageAdapter.tsx
@@ -1,12 +1,13 @@
-import { utils } from '@raulmelo/core';
-
+import {
+  imgUrlFor,
+  getImageDimensionsFromSanityImageUrl,
+  type SanityImageSource,
+} from '@raulmelo/core/utils';
 import { Image } from './Image';
 
-type SanityImageSource = Parameters<typeof utils[`imgUrlFor`]>;
-
 export function ImageAdapter({ asset }: { asset: SanityImageSource }) {
-  const src = utils.imgUrlFor(asset).url();
-  const imgDimensions = utils.getImageDimensionsFromSanityImageUrl(src);
+  const src = imgUrlFor(asset).url();
+  const imgDimensions = getImageDimensionsFromSanityImageUrl(src);
 
   return <Image {...imgDimensions} image={{ url: src, ...imgDimensions }} />;
 }

--- a/apps/website-remix/app/ui/PortableTextPost/components/ImageSliderAdapter.tsx
+++ b/apps/website-remix/app/ui/PortableTextPost/components/ImageSliderAdapter.tsx
@@ -1,16 +1,21 @@
-import { utils } from '@raulmelo/core';
+import {
+  isNil,
+  isEmpty,
+  imgUrlFor,
+  getImageDimensionsFromSanityImageUrl,
+} from '@raulmelo/core/utils';
 import { ImageSlider } from '@raulmelo/ui';
 
 export function ImageSliderAdapter({ images }: SanityBlock) {
-  if (utils.isNil(images) || utils.isEmpty(images)) {
+  if (isNil(images) || isEmpty(images)) {
     return null;
   }
 
   const adaptedImages = images.map((img) => {
     const { alt, caption, height, width, image } = img;
-    const src = utils.imgUrlFor(image).url();
+    const src = imgUrlFor(image).url();
 
-    const imgDimensions = utils.getImageDimensionsFromSanityImageUrl(src);
+    const imgDimensions = getImageDimensionsFromSanityImageUrl(src);
 
     return {
       alt,

--- a/apps/website-remix/app/ui/screens/blog/SeriesSection.tsx
+++ b/apps/website-remix/app/ui/screens/blog/SeriesSection.tsx
@@ -1,5 +1,5 @@
 import { useLocalization } from '$infrastructure/contexts/Localization';
-import { getPostUrl } from '$infrastructure/utils/url';
+import getPostUrl from '$infrastructure/utils/url';
 import type { BlogPostBySlug } from '@raulmelo/core/dist/types/domains/posts/queryPostBySlug/types';
 import { ChevronDownIcon } from '@raulmelo/ui';
 import { Link } from '@remix-run/react';

--- a/apps/website-remix/app/ui/screens/home/Posts.tsx
+++ b/apps/website-remix/app/ui/screens/home/Posts.tsx
@@ -1,5 +1,5 @@
 import { useLocalization } from '$infrastructure/contexts/Localization';
-import { getPostUrl } from '$infrastructure/utils/url';
+import getPostUrl from '$infrastructure/utils/url';
 import { ContentTile } from '$ui/ContentTile';
 import type { IPostsAndTilsPost } from '@raulmelo/core/dist/types/domains/posts';
 import { AnimatePresence, m } from 'framer-motion';

--- a/apps/website-remix/environment.d.ts
+++ b/apps/website-remix/environment.d.ts
@@ -1,4 +1,4 @@
-import type { AppTheme } from '@raulmelo/core';
+import type { AppTheme } from '@raulmelo/core/config';
 
 declare global {
   interface Window {

--- a/apps/website-remix/remix.config.js
+++ b/apps/website-remix/remix.config.js
@@ -17,6 +17,7 @@ module.exports = {
   server: process.env.NODE_ENV === `development` ? undefined : `./server.js`,
   ignoredRouteFiles: [`**/.*`],
   serverDependenciesToBundle: [
+    `@raulmelo/core`,
     `query-string`,
     /**
      * Without this being included it'll throw an error in Vercel because

--- a/apps/website/src/components/PortableTextPost/PortableTextPost.tsx
+++ b/apps/website/src/components/PortableTextPost/PortableTextPost.tsx
@@ -1,5 +1,5 @@
 import { PortableText } from '@portabletext/react';
-import type { SupportedLanguages } from '@raulmelo/core';
+import type { SupportedLanguages } from '@raulmelo/core/config';
 import { ProseContainer } from '@raulmelo/ui';
 import Link from 'next/link';
 import { useRouter } from 'next/router';

--- a/apps/website/src/components/PortableTextPost/components/ImageAdapter.tsx
+++ b/apps/website/src/components/PortableTextPost/components/ImageAdapter.tsx
@@ -1,8 +1,11 @@
-import { utils } from '@raulmelo/core';
+import {
+  getImageDimensionsFromSanityImageUrl,
+  imgUrlFor,
+} from '@raulmelo/core/utils';
 
 import { Image } from './Image';
 
-type SanityImageSource = Parameters<typeof utils['imgUrlFor']>;
+type SanityImageSource = Parameters<typeof imgUrlFor>;
 
 export function ImageAdapter({
   value,
@@ -10,8 +13,8 @@ export function ImageAdapter({
   value: { asset: SanityImageSource };
 }) {
   const { asset } = value;
-  const src = utils.imgUrlFor(asset).url();
-  const imgDimensions = utils.getImageDimensionsFromSanityImageUrl(src);
+  const src = imgUrlFor(asset).url();
+  const imgDimensions = getImageDimensionsFromSanityImageUrl(src);
 
   return <Image {...imgDimensions} image={{ url: src, ...imgDimensions }} />;
 }

--- a/apps/website/src/components/PortableTextPost/components/ImageSliderAdapter.tsx
+++ b/apps/website/src/components/PortableTextPost/components/ImageSliderAdapter.tsx
@@ -1,19 +1,24 @@
-import { utils } from '@raulmelo/core';
+import {
+  getImageDimensionsFromSanityImageUrl,
+  imgUrlFor,
+  isEmpty,
+  isNil,
+} from '@raulmelo/core/utils';
 import { ImageSlider } from '@raulmelo/ui';
 import NextImage from 'next/image';
 
 export function ImageSliderAdapter({ value }: SanityBlock) {
   const { images } = value;
 
-  if (utils.isNil(images) || utils.isEmpty(images)) {
+  if (isNil(images) || isEmpty(images)) {
     return null;
   }
 
   const adaptedImages = images.map((img) => {
     const { alt, caption, height, width, image } = img;
-    const src = utils.imgUrlFor(image).url();
+    const src = imgUrlFor(image).url();
 
-    const imgDimensions = utils.getImageDimensionsFromSanityImageUrl(src);
+    const imgDimensions = getImageDimensionsFromSanityImageUrl(src);
 
     return {
       alt,

--- a/apps/website/src/components/PostBasic/PostBasic.tsx
+++ b/apps/website/src/components/PostBasic/PostBasic.tsx
@@ -1,4 +1,4 @@
-import type { QueryPostsAndTilsReturnType } from '@raulmelo/core/dist/types/domains/posts';
+import type { QueryPostsAndTilsReturnType } from '@raulmelo/core/domains';
 import classNames from 'classnames';
 import Link from 'next/link';
 import { FormattedDate } from 'react-intl';

--- a/apps/website/src/contexts/Localization.tsx
+++ b/apps/website/src/contexts/Localization.tsx
@@ -1,4 +1,4 @@
-import type { SupportedLanguages } from '@raulmelo/core';
+import type { SupportedLanguages } from '@raulmelo/core/config';
 import flat from 'flat';
 import { useRouter } from 'next/router';
 import { createContext, useMemo } from 'react';

--- a/apps/website/src/hooks/useLocalization.ts
+++ b/apps/website/src/hooks/useLocalization.ts
@@ -1,13 +1,10 @@
-import type { SupportedLanguages } from '@raulmelo/core';
+import type { SupportedLanguages } from '@raulmelo/core/config';
 import { useContext } from 'react';
-import type { IntlShape} from 'react-intl';
+import type { IntlShape } from 'react-intl';
 import { useIntl } from 'react-intl';
 
-import type {
-  LocalizationContextType} from '~/contexts/Localization';
-import {
-  LocalizationContext
-} from '~/contexts/Localization';
+import type { LocalizationContextType } from '~/contexts/Localization';
+import { LocalizationContext } from '~/contexts/Localization';
 
 /**
  * react-intl has "locale" which is a string.

--- a/apps/website/src/hooks/useScrollToTop.ts
+++ b/apps/website/src/hooks/useScrollToTop.ts
@@ -1,7 +1,7 @@
-import { utils } from '@raulmelo/core';
+import { isBrowserApiAvailable } from '@raulmelo/core/utils';
 import { polyfill as scrollPolyfill } from 'smoothscroll-polyfill';
 
-if (utils.isBrowserApiAvailable.window) {
+if (isBrowserApiAvailable.window) {
   scrollPolyfill();
 }
 

--- a/apps/website/src/hooks/useThemeHandler.ts
+++ b/apps/website/src/hooks/useThemeHandler.ts
@@ -1,5 +1,5 @@
-import type { AppTheme } from '@raulmelo/core';
-import { utils } from '@raulmelo/core';
+import type { AppTheme } from '@raulmelo/core/config';
+import { isBrowserApiAvailable } from '@raulmelo/core/utils';
 import { useMachine } from '@xstate/react';
 import { createMachine } from 'xstate';
 
@@ -83,7 +83,7 @@ const themeMachine = createMachine(
          * Because NEXT will run this on node first, I have to check
          * if the window is defined before checking the __theme property.
          */
-        if (utils.isBrowserApiAvailable.window) {
+        if (typeof window !== 'undefined') {
           if (window.__theme) {
             result = window.__theme === 'light';
           }

--- a/apps/website/src/pages/_app.page.tsx
+++ b/apps/website/src/pages/_app.page.tsx
@@ -4,7 +4,7 @@ import '@raulmelo/styles/lib/styles.css';
 import '../styles/algolia-global.css';
 import '../styles/globals.css';
 
-import type { SupportedLanguages } from '@raulmelo/core';
+import type { SupportedLanguages } from '@raulmelo/core/config';
 import type { NextPage } from 'next';
 import type { AppProps } from 'next/dist/shared/lib/router/router';
 import Head from 'next/head';

--- a/apps/website/src/pages/blog/[slug]/index.page.tsx
+++ b/apps/website/src/pages/blog/[slug]/index.page.tsx
@@ -1,4 +1,5 @@
-import { domains, utils } from '@raulmelo/core';
+import { queryPostBySlug, queryPosts } from '@raulmelo/core/domains';
+import { getEstimatedReadingTime, isEmpty, isNil } from '@raulmelo/core/utils';
 import { DotDivider } from '@raulmelo/ui';
 import type { GetStaticPaths } from 'next';
 import { Suspense } from 'react';
@@ -37,17 +38,15 @@ export const BlogPostPage = ({ post, estimatedReadingTime }: BlogPostProps) => {
 };
 
 export const getStaticProps = async ({ params, preview }: GetStaticProps) => {
-  const post = await domains.posts.queryPostBySlug(params.slug);
+  const post = await queryPostBySlug(params.slug);
 
-  if (utils.isNil(post) || utils.isEmpty(post)) {
+  if (isNil(post) || isEmpty(post)) {
     return {
       notFound: true,
     };
   }
 
-  const estimatedReadingTime = utils.content.getEstimatedReadingTime(
-    post.content,
-  );
+  const estimatedReadingTime = getEstimatedReadingTime(post.content);
 
   return {
     props: {
@@ -60,7 +59,7 @@ export const getStaticProps = async ({ params, preview }: GetStaticProps) => {
 };
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const posts = await domains.posts.queryPosts('all');
+  const posts = await queryPosts('all');
 
   const paths = posts.map((post) => ({
     params: {

--- a/apps/website/src/pages/blog/[slug]/types.ts
+++ b/apps/website/src/pages/blog/[slug]/types.ts
@@ -1,4 +1,4 @@
-import type { QueryPostBySlugReturnType } from '@raulmelo/core/dist/types/domains/posts/queryPostBySlug';
+import type { QueryPostBySlugReturnType } from '@raulmelo/core/domains';
 
 export type BlogPostProps = {
   post: QueryPostBySlugReturnType;

--- a/apps/website/src/pages/blog/home/BlogPage.tsx
+++ b/apps/website/src/pages/blog/home/BlogPage.tsx
@@ -1,4 +1,4 @@
-import type { QueryPostsReturnType } from '@raulmelo/core/dist/types/domains/posts/queryPosts';
+import type { QueryPostsReturnType } from '@raulmelo/core/domains';
 import { NextSeo } from 'next-seo';
 import { defineMessages, FormattedMessage } from 'react-intl';
 

--- a/apps/website/src/pages/blog/home/index.page.tsx
+++ b/apps/website/src/pages/blog/home/index.page.tsx
@@ -1,6 +1,6 @@
-import type { SupportedLanguages } from '@raulmelo/core';
-import { domains } from '@raulmelo/core';
-import type { QueryPostsReturnType } from '@raulmelo/core/dist/types/domains/posts/queryPosts';
+import type { SupportedLanguages } from '@raulmelo/core/config';
+import type { QueryPostsReturnType } from '@raulmelo/core/domains';
+import { queryPosts } from '@raulmelo/core/domains';
 import type { GetStaticProps } from 'next';
 
 import { Blog } from './BlogPage';
@@ -12,7 +12,7 @@ const BlogPage = ({ posts }: BlogPageProps) => {
 };
 
 export const getStaticProps: GetStaticProps = async ({ locale }) => {
-  const posts = await domains.posts.queryPosts(locale as SupportedLanguages);
+  const posts = await queryPosts(locale as SupportedLanguages);
 
   return {
     props: {

--- a/apps/website/src/pages/home/HomePage.tsx
+++ b/apps/website/src/pages/home/HomePage.tsx
@@ -1,4 +1,4 @@
-import type { QueryPostsAndTilsReturnType } from '@raulmelo/core/dist/types/domains/posts/queryPostsAndTils';
+import type { QueryPostsAndTilsReturnType } from '@raulmelo/core/domains';
 import { ArrowRightIcon } from '@raulmelo/ui';
 import Link from 'next/link';
 import { NextSeo } from 'next-seo';

--- a/apps/website/src/pages/home/components/Posts.tsx
+++ b/apps/website/src/pages/home/components/Posts.tsx
@@ -1,4 +1,4 @@
-import type { QueryPostsAndTilsReturnType } from '@raulmelo/core/dist/types/domains/posts/queryPostsAndTils';
+import type { QueryPostsAndTilsReturnType } from '@raulmelo/core/domains';
 import { AnimatePresence, m } from 'framer-motion';
 
 import { ContentTile } from '~/components/ContentTile';

--- a/apps/website/src/pages/home/index.page.tsx
+++ b/apps/website/src/pages/home/index.page.tsx
@@ -1,6 +1,6 @@
-import type { SupportedLanguages } from '@raulmelo/core';
-import { domains } from '@raulmelo/core';
-import type { QueryPostsAndTilsReturnType } from '@raulmelo/core/dist/types/domains/posts/queryPostsAndTils';
+import type { SupportedLanguages } from '@raulmelo/core/config';
+import type { QueryPostsAndTilsReturnType } from '@raulmelo/core/domains';
+import { queryPostsAndTils } from '@raulmelo/core/domains';
 import type { GetStaticProps } from 'next';
 
 import { HomePage } from './HomePage';
@@ -11,7 +11,7 @@ export default function Home(props: QueryPostsAndTilsReturnType) {
 
 export const getStaticProps: GetStaticProps = async ({ locale }) => {
   const NUMBER_OF_POSTS = 2;
-  const { posts, tils } = await domains.posts.queryPostsAndTils(
+  const { posts, tils } = await queryPostsAndTils(
     locale as SupportedLanguages,
     NUMBER_OF_POSTS,
   );

--- a/apps/website/src/pages/home/types.ts
+++ b/apps/website/src/pages/home/types.ts
@@ -1,4 +1,4 @@
-import type { QueryPostsAndTilsReturnType } from '@raulmelo/core/dist/types/domains/posts';
+import type { QueryPostsAndTilsReturnType } from '@raulmelo/core/domains';
 
 export type PostSectionProps = {
   title: string;

--- a/apps/website/src/pages/search/components/Filters.tsx
+++ b/apps/website/src/pages/search/components/Filters.tsx
@@ -1,4 +1,4 @@
-import { utils } from '@raulmelo/core';
+import { isEmpty } from '@raulmelo/core/utils';
 import classNames from 'classnames';
 import { connectRefinementList } from 'react-instantsearch-dom';
 
@@ -76,7 +76,7 @@ function GenericRefinement({
   items,
   renderLabelText,
 }: GenericRefinementProps) {
-  return utils.isEmpty(items) ? null : (
+  return isEmpty(items) ? null : (
     <div className={styles.RefinementWrapper}>
       <h3 className="text-lg font-bold">{title}</h3>
 

--- a/apps/website/src/pages/search/types.ts
+++ b/apps/website/src/pages/search/types.ts
@@ -1,4 +1,4 @@
-import type { AlgoliaObject } from '@raulmelo/core/dist/types/domains/algolia';
+import type { AlgoliaObject } from '@raulmelo/core/domains';
 
 export type HitAlgolia = AlgoliaObject;
 

--- a/apps/website/src/pages/tag/TagPage.tsx
+++ b/apps/website/src/pages/tag/TagPage.tsx
@@ -1,4 +1,4 @@
-import { utils } from '@raulmelo/core';
+import { isEmpty } from '@raulmelo/core/utils';
 import { NextSeo } from 'next-seo';
 import { useMemo } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
@@ -59,7 +59,7 @@ export const TagPage = ({ tag, content }: TagPageProps) => {
       <h2 className="mb-4 font-sans text-xl font-extrabold col-span-full lg:text-2xl lg:mb-8">
         {title}
       </h2>
-      {utils.isEmpty(content) ? (
+      {isEmpty(content) ? (
         <p className="text-lg col-span-full">
           <FormattedMessage id="tag.empty" />
         </p>

--- a/apps/website/src/pages/tag/[slug].page.tsx
+++ b/apps/website/src/pages/tag/[slug].page.tsx
@@ -1,5 +1,9 @@
-import type { SupportedLanguages } from '@raulmelo/core';
-import { domains } from '@raulmelo/core';
+import type { SupportedLanguages } from '@raulmelo/core/config';
+import {
+  queryAllTags,
+  queryTagBySlug,
+  sortPostsByPublishedDate,
+} from '@raulmelo/core/domains';
 import type { GetStaticPaths } from 'next';
 
 import { TagPage } from './TagPage';
@@ -8,12 +12,9 @@ import type { TagPageParams, TagPageProps } from './types';
 const Tag = (props: TagPageProps) => <TagPage {...props} />;
 
 export const getStaticProps = async ({ params, locale }: TagPageParams) => {
-  const tag = await domains.tag.queryTagBySlug(params.slug, locale);
+  const tag = await queryTagBySlug(params.slug, locale);
 
-  const content = domains.posts.sortPostsByPublishedDate([
-    ...tag.posts,
-    ...tag.tils,
-  ]);
+  const content = sortPostsByPublishedDate([...tag.posts, ...tag.tils]);
 
   return {
     props: {
@@ -25,7 +26,7 @@ export const getStaticProps = async ({ params, locale }: TagPageParams) => {
 };
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const postTags = await domains.tag.queryAllTags();
+  const postTags = await queryAllTags();
 
   const paths: TagPageParams[] = [];
 

--- a/apps/website/src/pages/tag/types.ts
+++ b/apps/website/src/pages/tag/types.ts
@@ -1,8 +1,8 @@
-import type { SupportedLanguages } from '@raulmelo/core';
+import type { SupportedLanguages } from '@raulmelo/core/config';
 import type {
   QueryTagBySlugPost,
   QueryTagBySlugTil,
-} from '@raulmelo/core/dist/types/domains/tag/queryTagBySlug';
+} from '@raulmelo/core/domains';
 
 type TagOrPost = QueryTagBySlugPost | QueryTagBySlugTil;
 

--- a/apps/website/src/pages/til/home/TilsHome.tsx
+++ b/apps/website/src/pages/til/home/TilsHome.tsx
@@ -1,4 +1,4 @@
-import type { QueryTilsReturnType } from '@raulmelo/core/dist/types/domains/posts/queryTils';
+import type { QueryTilsReturnType } from '@raulmelo/core/domains';
 import classNames from 'classnames';
 import { NextSeo } from 'next-seo';
 import { FormattedMessage } from 'react-intl';

--- a/apps/website/src/pages/til/home/index.page.tsx
+++ b/apps/website/src/pages/til/home/index.page.tsx
@@ -1,6 +1,6 @@
-import type { SupportedLanguagesWithAll } from '@raulmelo/core';
-import { domains } from '@raulmelo/core';
-import type { QueryTilsReturnType } from '@raulmelo/core/dist/types/domains/posts/queryTils';
+import type { SupportedLanguagesWithAll } from '@raulmelo/core/config';
+import type { QueryTilsReturnType } from '@raulmelo/core/domains';
+import { queryTils } from '@raulmelo/core/domains';
 import type { GetStaticProps } from 'next';
 
 import { TilsHome } from './TilsHome';
@@ -10,9 +10,7 @@ type Til = QueryTilsReturnType[number];
 const TilsPage = (props: { tils: Til[] }) => <TilsHome {...props} />;
 
 export const getStaticProps: GetStaticProps = async ({ locale }) => {
-  const tils = await domains.posts.queryTils(
-    locale as SupportedLanguagesWithAll,
-  );
+  const tils = await queryTils(locale as SupportedLanguagesWithAll);
 
   return {
     props: {

--- a/apps/website/src/pages/uses/UsesPage.tsx
+++ b/apps/website/src/pages/uses/UsesPage.tsx
@@ -1,4 +1,4 @@
-import type { GetUsesReturnType } from '@raulmelo/core/dist/types/domains/uses';
+import type { GetUsesReturnType } from '@raulmelo/core/domains';
 
 import { PortableTextPost } from '~/components/PortableTextPost';
 import { useLocalization } from '~/hooks/useLocalization';

--- a/apps/website/src/pages/uses/index.page.tsx
+++ b/apps/website/src/pages/uses/index.page.tsx
@@ -1,5 +1,6 @@
-import type { SupportedLanguages} from '@raulmelo/core';
-import { domains, utils } from '@raulmelo/core';
+import type { SupportedLanguages } from '@raulmelo/core/config';
+import { getUses } from '@raulmelo/core/domains';
+import { getEstimatedReadingTime } from '@raulmelo/core/utils';
 import type { GetStaticProps } from 'next';
 
 import type { UsesPageProps } from './UsesPage';
@@ -17,11 +18,9 @@ const Uses = ({ uses, seo, title, estimatedReadingTime }: UsesPageProps) => {
 };
 
 export const getStaticProps: GetStaticProps = async ({ locale }) => {
-  const uses = await domains.uses.getUses(locale as SupportedLanguages);
+  const uses = await getUses(locale as SupportedLanguages);
 
-  const estimatedReadingTime = utils.content.getEstimatedReadingTime(
-    uses.content,
-  );
+  const estimatedReadingTime = getEstimatedReadingTime(uses.content);
   return {
     props: {
       uses,

--- a/apps/website/src/utils/url.ts
+++ b/apps/website/src/utils/url.ts
@@ -1,4 +1,4 @@
-import type { SupportedLanguages } from '@raulmelo/core';
+import type { SupportedLanguages } from '@raulmelo/core/config';
 
 /**
  * TODO: Move those functions to core/domains/*

--- a/apps/website/types/env.d.ts
+++ b/apps/website/types/env.d.ts
@@ -1,4 +1,4 @@
-import { AppTheme } from '@raulmelo/core';
+import { AppTheme } from '@raulmelo/core/config';
 
 declare global {
   interface Window {

--- a/packages/core/.eslintrc.cjs
+++ b/packages/core/.eslintrc.cjs
@@ -5,7 +5,7 @@ module.exports = {
     '@typescript-eslint/consistent-type-assertions': 'error',
     '@typescript-eslint/consistent-type-imports': [
       'error',
-      { disallowTypeAnnotations: false },
+      { disallowTypeAnnotations: false, fixStyle: 'inline-type-imports' },
     ],
   },
 };

--- a/packages/core/config.d.ts
+++ b/packages/core/config.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/config';

--- a/packages/core/domains.d.ts
+++ b/packages/core/domains.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/domains';

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -1,0 +1,4 @@
+/// <reference path="./config.d.ts" />
+/// <reference path="./domains.d.ts" />
+/// <reference path="./scripts.d.ts" />
+/// <reference path="./utils.d.ts" />

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,26 +23,26 @@
   },
   "dependencies": {
     "@sanity/block-content-to-markdown": "0.0.5",
-    "@sanity/client": "5.2.1",
+    "@sanity/client": "5.2.2",
     "@sanity/image-url": "1.0.2",
-    "groq": "3.4.0",
+    "groq": "3.5.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "zod": "3.20.6"
   },
   "devDependencies": {
-    "@portabletext/react": "2.0.1",
+    "@portabletext/react": "2.0.2",
     "@portabletext/types": "2.0.2",
-    "@types/node": "18.14.0",
+    "@types/node": "18.14.2",
     "@types/ramda": "0.28.23",
-    "@typescript-eslint/parser": "5.52.0",
-    "eslint": "8.34.0",
+    "@typescript-eslint/parser": "5.54.0",
+    "eslint": "8.35.0",
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-simple-import-sort": "10.0.0",
     "ramda": "0.28.0",
     "typescript": "4.9.5",
-    "vite": "4.1.2",
-    "vitest": "0.28.5"
+    "vite": "4.1.4",
+    "vitest": "0.29.2"
   },
   "scripty": {
     "path": "./scripts"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,19 +1,37 @@
 {
   "private": true,
   "name": "@raulmelo/core",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "license": "MIT",
   "type": "module",
-  "main": "./dist/core.cjs",
-  "module": "./dist/core.js",
+  "files": [
+    "dist",
+    "index.d.ts",
+    "config.d.ts",
+    "domains.d.ts",
+    "utils.d.ts",
+    "scripts.d.ts",
+    "types"
+  ],
   "exports": {
-    ".": {
-      "require": "./dist/core.cjs",
-      "default": "./dist/core.js"
+    "./domains": {
+      "require": "./dist/domains/index.cjs",
+      "default": "./dist/domains/index.js"
     },
-    "./scripts": "./dist/scripts.js"
+    "./utils": {
+      "require": "./dist/utils/index.cjs",
+      "default": "./dist/utils/index.js"
+    },
+    "./config": {
+      "require": "./dist/config/index.cjs",
+      "default": "./dist/config/index.js"
+    },
+    "./scripts": {
+      "require": "./dist/scripts/index.cjs",
+      "default": "./dist/scripts/index.js"
+    }
   },
-  "types": "./dist/types/index.d.ts",
+  "types": "./index.d.ts",
   "scripts": {
     "clean": "scripty",
     "build": "scripty",

--- a/packages/core/scripts.d.ts
+++ b/packages/core/scripts.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/scripts';

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -1,0 +1,3 @@
+export * from './languages';
+export * from './sanity';
+export * from './theme';

--- a/packages/core/src/domains/algolia/queryAlgoliaData.ts
+++ b/packages/core/src/domains/algolia/queryAlgoliaData.ts
@@ -2,9 +2,8 @@ import type { PortableTextBlock } from '@portabletext/types';
 import groq from 'groq';
 import { z } from 'zod';
 
-import { supportedLanguagesSchema } from '$config/languages';
-import { client } from '$config/sanity';
-import { contentBlockToMarkdown } from '$utils/contentBlockToMarkdown';
+import { client, supportedLanguagesSchema } from '@/config';
+import { contentBlockToMarkdown } from '@/utils';
 
 export async function queryAlgoliaData() {
   const posts = await client.fetch(algoliaPostsQuery);

--- a/packages/core/src/domains/index.ts
+++ b/packages/core/src/domains/index.ts
@@ -1,15 +1,6 @@
-import * as algolia from './algolia';
-import * as posts from './posts';
-import * as rss from './rss';
-import * as siteData from './siteData';
-import * as tag from './tag';
-import * as uses from './uses';
-
-export const domains = {
-  siteData,
-  algolia,
-  uses,
-  tag,
-  posts,
-  rss,
-};
+export * from './algolia';
+export * from './posts';
+export * from './rss';
+export * from './siteData';
+export * from './tag';
+export * from './uses';

--- a/packages/core/src/domains/posts/queryPostBySlug.ts
+++ b/packages/core/src/domains/posts/queryPostBySlug.ts
@@ -2,8 +2,7 @@ import type { PortableTextBlock } from '@portabletext/types';
 import groq from 'groq';
 import { z } from 'zod';
 
-import { supportedLanguagesSchema } from '$config/languages';
-import { client } from '$config/sanity';
+import { client, supportedLanguagesSchema } from '@/config';
 
 export async function queryPostBySlug(slug: string) {
   const result = await client.fetch(postQuery, {

--- a/packages/core/src/domains/posts/queryPosts.ts
+++ b/packages/core/src/domains/posts/queryPosts.ts
@@ -1,12 +1,12 @@
 import groq from 'groq';
 import { z } from 'zod';
 
-import type { SupportedLanguagesWithAll } from '$config/languages';
 import {
+  client,
   SUPPORTED_LANGUAGES,
   supportedLanguagesSchema,
-} from '$config/languages';
-import { client } from '$config/sanity';
+  type SupportedLanguagesWithAll,
+} from '@/config';
 
 export async function queryPosts(language: SupportedLanguagesWithAll) {
   const languages = language === 'all' ? SUPPORTED_LANGUAGES : [language];

--- a/packages/core/src/domains/posts/queryPostsAndTils.ts
+++ b/packages/core/src/domains/posts/queryPostsAndTils.ts
@@ -1,9 +1,11 @@
 import groq from 'groq';
 import { z } from 'zod';
 
-import type { SupportedLanguages } from '$config/languages';
-import { supportedLanguagesSchema } from '$config/languages';
-import { client } from '$config/sanity';
+import {
+  client,
+  type SupportedLanguages,
+  supportedLanguagesSchema,
+} from '@/config';
 
 export async function queryPostsAndTils(
   locale: SupportedLanguages,

--- a/packages/core/src/domains/posts/queryTilBySlug.ts
+++ b/packages/core/src/domains/posts/queryTilBySlug.ts
@@ -2,8 +2,7 @@ import type { PortableTextBlock } from '@portabletext/types';
 import groq from 'groq';
 import { z } from 'zod';
 
-import { supportedLanguagesSchema } from '$config/languages';
-import { client } from '$config/sanity';
+import { client, supportedLanguagesSchema } from '@/config';
 
 export async function queryTilBySlug(slug: string) {
   const result = await client.fetch(tilBySlugQuery, {

--- a/packages/core/src/domains/posts/queryTils.ts
+++ b/packages/core/src/domains/posts/queryTils.ts
@@ -2,12 +2,12 @@ import type { PortableTextBlock } from '@portabletext/types';
 import groq from 'groq';
 import { z } from 'zod';
 
-import type { SupportedLanguagesWithAll } from '$config/languages';
 import {
+  client,
   SUPPORTED_LANGUAGES_WITH_ALL,
   supportedLanguagesSchema,
-} from '$config/languages';
-import { client } from '$config/sanity';
+  type SupportedLanguagesWithAll,
+} from '@/config';
 
 export async function queryTils(language: SupportedLanguagesWithAll) {
   const languages =
@@ -18,7 +18,7 @@ export async function queryTils(language: SupportedLanguagesWithAll) {
   return tilsSchema.parse(result);
 }
 
-export type QueryTilsReturnType = Awaited<ReturnType<typeof queryTils>>;
+export type QueryTilsReturnType = z.infer<typeof tilsSchema>;
 
 const tilQuery = groq`
 *[_type == "til" && language in $languages && !(_id in path('drafts.**'))] | order(publishedAt desc){

--- a/packages/core/src/domains/rss/queryRssData.ts
+++ b/packages/core/src/domains/rss/queryRssData.ts
@@ -1,9 +1,11 @@
 import groq from 'groq';
 import { z } from 'zod';
 
-import type { SupportedLanguages } from '$config/languages';
-import { supportedLanguagesSchema } from '$config/languages';
-import { client } from '$config/sanity';
+import {
+  client,
+  type SupportedLanguages,
+  supportedLanguagesSchema,
+} from '@/config';
 
 export async function queryRssData(language: SupportedLanguages) {
   const result = await client.fetch(rssQuery, { language: language });

--- a/packages/core/src/domains/siteData/querySiteData.ts
+++ b/packages/core/src/domains/siteData/querySiteData.ts
@@ -1,8 +1,7 @@
 import groq from 'groq';
 import { z } from 'zod';
 
-import { supportedLanguagesSchema } from '$config/languages';
-import { client } from '$config/sanity';
+import { client, supportedLanguagesSchema } from '@/config';
 
 export async function querySiteData() {
   const [defaultSeoPt, defaultSeoEn, personalInformation, site, socials] =

--- a/packages/core/src/domains/tag/queryAllTags.ts
+++ b/packages/core/src/domains/tag/queryAllTags.ts
@@ -1,7 +1,7 @@
 import groq from 'groq';
 import { z } from 'zod';
 
-import { client } from '$config/sanity';
+import { client } from '@/config';
 
 export async function queryAllTags() {
   const result = await client.fetch(allTagsQuery);

--- a/packages/core/src/domains/tag/queryTagBySlug.ts
+++ b/packages/core/src/domains/tag/queryTagBySlug.ts
@@ -1,9 +1,11 @@
 import groq from 'groq';
 import { z } from 'zod';
 
-import type { SupportedLanguages } from '$config/languages';
-import { supportedLanguagesSchema } from '$config/languages';
-import { client } from '$config/sanity';
+import {
+  client,
+  type SupportedLanguages,
+  supportedLanguagesSchema,
+} from '@/config';
 
 export async function queryTagBySlug(
   slug: string,

--- a/packages/core/src/domains/uses/getUses.ts
+++ b/packages/core/src/domains/uses/getUses.ts
@@ -2,9 +2,11 @@ import type { PortableTextBlock } from '@portabletext/types';
 import groq from 'groq';
 import { z } from 'zod';
 
-import type { SupportedLanguages } from '$config/languages';
-import { supportedLanguagesSchema } from '$config/languages';
-import { client } from '$config/sanity';
+import {
+  client,
+  type SupportedLanguages,
+  supportedLanguagesSchema,
+} from '@/config';
 
 export async function getUses(language: SupportedLanguages) {
   const result = await client.fetch(getUsesQuery, { language });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,0 @@
-export * from './config/languages';
-export * from './config/sanity';
-export * from './config/theme';
-export * from './domains';
-export * from './utils';

--- a/packages/core/src/scripts/generateRssFeed.ts
+++ b/packages/core/src/scripts/generateRssFeed.ts
@@ -1,10 +1,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-import type { SupportedLanguages } from '$config/languages';
-import { domains } from '$domains';
-import { sortPostsByPublishedDate } from '$domains/posts';
-import type { QueryRssDataReturnType } from '$domains/rss';
+import { type SupportedLanguages } from '@/config';
+import {
+  queryRssData,
+  type QueryRssDataReturnType,
+  sortPostsByPublishedDate,
+} from '@/domains';
 
 type IRssConfig = Omit<QueryRssDataReturnType, 'posts' | 'tils'>;
 
@@ -16,9 +18,7 @@ export async function generateRssFeed(config: IConfig): Promise<void> {
   const { outdir } = config;
 
   for await (const language of ['en', 'pt'] as const) {
-    const { tils, posts, ...restData } = await domains.rss.queryRssData(
-      language,
-    );
+    const { tils, posts, ...restData } = await queryRssData(language);
 
     const rssConfig: IRssConfig = {
       ...restData,

--- a/packages/core/src/scripts/generateSiteData.ts
+++ b/packages/core/src/scripts/generateSiteData.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 
-import { domains } from '$domains';
+import { querySiteData } from '@/domains';
 
 interface IConfig {
   outdir: string;
@@ -11,8 +11,7 @@ export async function generateSiteData(config: IConfig): Promise<void> {
   const { outdir, fileName = 'site-data' } = config;
 
   try {
-    const { personalInformation, ...rest } =
-      await domains.siteData.querySiteData();
+    const { personalInformation, ...rest } = await querySiteData();
 
     const { profilePic, ...restPersonalInfo } = personalInformation;
     /**

--- a/packages/core/src/utils/image.ts
+++ b/packages/core/src/utils/image.ts
@@ -1,6 +1,6 @@
 import imageUrlBuilder from '@sanity/image-url';
 
-import { sanityConfig } from '$config/sanity';
+import { sanityConfig } from '@/config';
 
 import { isNil } from './ramda';
 

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,13 +1,5 @@
-import { getEstimatedReadingTime } from './getEstimatedReadingTime';
-import * as imageUtils from './image';
-import * as ramdaUtils from './ramda';
-import * as utilities from './utilities';
-
-export const utils = {
-  ...utilities,
-  ...ramdaUtils,
-  ...imageUtils,
-  content: {
-    getEstimatedReadingTime,
-  },
-};
+export * from './contentBlockToMarkdown';
+export * from './getEstimatedReadingTime';
+export * from './image';
+export * from './ramda';
+export * from './utilities';

--- a/packages/core/src/utils/ramda.ts
+++ b/packages/core/src/utils/ramda.ts
@@ -1,7 +1,11 @@
-import head from 'ramda/src/head';
-import isEmpty from 'ramda/src/isEmpty';
-import isNil from 'ramda/src/isNil';
-import not from 'ramda/src/not';
-import omit from 'ramda/src/omit';
+import Rhead from 'ramda/src/head';
+import RisEmpty from 'ramda/src/isEmpty';
+import RisNil from 'ramda/src/isNil';
+import Rnot from 'ramda/src/not';
+import Romit from 'ramda/src/omit';
 
-export { head, isEmpty, isNil, not, omit };
+export const isNil = RisNil;
+export const not = Rnot;
+export const head = Rhead;
+export const isEmpty = RisEmpty;
+export const omit = Romit;

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -7,23 +7,24 @@
     "moduleResolution": "node",
     "target": "esnext",
     "declaration": true,
-    "declarationDir": "./dist/types",
+    "declarationDir": "./dist",
     "emitDeclarationOnly": true,
     "skipLibCheck": true,
     "baseUrl": ".",
     "allowSyntheticDefaultImports": true,
+    "declarationMap": true,
     "paths": {
-      "$config/*": [
-        "src/config/*"
+      "@/config": [
+        "src/config/index.ts"
       ],
-      "$utils/*": [
-        "./src/utils/*"
+      "@/utils": [
+        "./src/utils/index.ts"
       ],
-      "$domains": [
+      "@/domains": [
         "./src/domains/index.ts"
       ],
-      "$domains/*": [
-        "./src/domains/*"
+      "@/scripts/*": [
+        "./src/scripts/index.ts"
       ]
     }
   },

--- a/packages/core/utils.d.ts
+++ b/packages/core/utils.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/utils';

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -4,9 +4,10 @@ import path from 'path';
 import { defineConfig } from 'vite';
 
 const aliases = {
-  $utils: path.resolve(__dirname, './src/utils'),
-  $config: path.resolve(__dirname, './src/config'),
-  $domains: path.resolve(__dirname, './src/domains'),
+  '@/utils': path.resolve(__dirname, './src/utils'),
+  '@/config': path.resolve(__dirname, './src/config'),
+  '@/domains': path.resolve(__dirname, './src/domains'),
+  '@/scripts': path.resolve(__dirname, './src/scripts'),
 };
 
 /**
@@ -35,7 +36,6 @@ const config = defineConfig({
     globals: true,
   },
   resolve: {
-    preserveSymlinks: true,
     alias: aliases,
   },
   build: {
@@ -43,12 +43,17 @@ const config = defineConfig({
     sourcemap: true,
     emptyOutDir: false,
     lib: {
-      fileName: '[name]',
-      entry: {
-        core: path.resolve(__dirname, 'src/index.ts'),
-        scripts: path.resolve(__dirname, 'src/scripts/index.ts'),
+      fileName: (format, entry) => {
+        const extension = format === 'cjs' ? 'cjs' : 'js';
+        return `${entry}/index.${extension}`;
       },
-      formats: ['es', 'cjs'],
+      entry: {
+        domains: path.resolve(__dirname, 'src/domains/index.ts'),
+        scripts: path.resolve(__dirname, 'src/scripts/index.ts'),
+        utils: path.resolve(__dirname, 'src/utils/index.ts'),
+        config: path.resolve(__dirname, 'src/config/index.ts'),
+      },
+      formats: ['es'],
     },
     rollupOptions: {
       external: isExternal,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -495,46 +495,46 @@ importers:
 
   packages/core:
     specifiers:
-      '@portabletext/react': 2.0.1
+      '@portabletext/react': 2.0.2
       '@portabletext/types': 2.0.2
       '@sanity/block-content-to-markdown': 0.0.5
-      '@sanity/client': 5.2.1
+      '@sanity/client': 5.2.2
       '@sanity/image-url': 1.0.2
-      '@types/node': 18.14.0
+      '@types/node': 18.14.2
       '@types/ramda': 0.28.23
-      '@typescript-eslint/parser': 5.52.0
-      eslint: 8.34.0
+      '@typescript-eslint/parser': 5.54.0
+      eslint: 8.35.0
       eslint-plugin-node: 11.1.0
       eslint-plugin-simple-import-sort: 10.0.0
-      groq: 3.4.0
+      groq: 3.5.0
       ramda: 0.28.0
       react: 18.2.0
       react-dom: 18.2.0
       typescript: 4.9.5
-      vite: 4.1.2
-      vitest: 0.28.5
+      vite: 4.1.4
+      vitest: 0.29.2
       zod: 3.20.6
     dependencies:
       '@sanity/block-content-to-markdown': 0.0.5
-      '@sanity/client': 5.2.1
+      '@sanity/client': 5.2.2
       '@sanity/image-url': 1.0.2
-      groq: 3.4.0
+      groq: 3.5.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       zod: 3.20.6
     devDependencies:
-      '@portabletext/react': 2.0.1_react@18.2.0
+      '@portabletext/react': 2.0.2_react@18.2.0
       '@portabletext/types': 2.0.2
-      '@types/node': 18.14.0
+      '@types/node': 18.14.2
       '@types/ramda': 0.28.23
-      '@typescript-eslint/parser': 5.52.0_7kw3g6rralp5ps6mg3uyzz6azm
-      eslint: 8.34.0
-      eslint-plugin-node: 11.1.0_eslint@8.34.0
-      eslint-plugin-simple-import-sort: 10.0.0_eslint@8.34.0
+      '@typescript-eslint/parser': 5.54.0_ycpbpc6yetojsgtrx3mwntkhsu
+      eslint: 8.35.0
+      eslint-plugin-node: 11.1.0_eslint@8.35.0
+      eslint-plugin-simple-import-sort: 10.0.0_eslint@8.35.0
       ramda: 0.28.0
       typescript: 4.9.5
-      vite: 4.1.2_@types+node@18.14.0
-      vitest: 0.28.5
+      vite: 4.1.4_@types+node@18.14.2
+      vitest: 0.29.2
 
   packages/sanity-core:
     specifiers:
@@ -3725,12 +3725,10 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@eslint/js/8.35.0:
     resolution: {integrity: sha512-JXdzbRiWclLVoD8sNUjR443VVlYqiYmDVT6rGUEIEHU5YJW0gaVZwV2xgM7D4arkvASqD0IlLUVjHiFuxaftRw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: false
 
   /@floating-ui/core/1.1.0:
     resolution: {integrity: sha512-zbsLwtnHo84w1Kc8rScAo5GMk1GdecSlrflIbfnEBJwvTSj1SL6kkOYV+nHraMCPEy+RNZZUaZyL8JosDGCtGQ==}
@@ -4746,8 +4744,8 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@portabletext/react/2.0.1_react@18.2.0:
-    resolution: {integrity: sha512-8uWtQKVkWBqxOuuXe7mULB15u7qVT1/Ys59SDSslrM1aXUhzzWQT68eDkdPd8+upbBvplFygAhZKkNCLDejYfQ==}
+  /@portabletext/react/2.0.2_react@18.2.0:
+    resolution: {integrity: sha512-8b325SwY4vAFP1Fu7coJUx/eOoenm197VnCWauJSH0zawwz6n8ouhFc5se1FKPpPPbJMqH3C+RGv2FOWQfB51A==}
     engines: {node: ^14.13.1 || >=16.0.0}
     peerDependencies:
       react: ^17 || ^18
@@ -8145,6 +8143,10 @@ packages:
   /@types/node/18.14.0:
     resolution: {integrity: sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==}
 
+  /@types/node/18.14.2:
+    resolution: {integrity: sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA==}
+    dev: true
+
   /@types/normalize-package-data/2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
 
@@ -8567,7 +8569,6 @@ packages:
       typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/scope-manager/5.46.1:
     resolution: {integrity: sha512-iOChVivo4jpwUdrJZyXSMrEIM/PvsbbDOX1y3UCKjSgWn+W89skxWaYXACQfxmIGhPVpRWK/VWPYc+bad6smIA==}
@@ -8614,7 +8615,6 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.54.0
       '@typescript-eslint/visitor-keys': 5.54.0
-    dev: false
 
   /@typescript-eslint/type-utils/5.46.1_ehfyfk7qbmgzg5nk6xmobqdh3a:
     resolution: {integrity: sha512-V/zMyfI+jDmL1ADxfDxjZ0EMbtiVqj8LUGPAGyBkXXStWmCUErMpW873zEHsyguWCuq2iN4BrlWUkmuVj84yng==}
@@ -8703,7 +8703,6 @@ packages:
   /@typescript-eslint/types/5.54.0:
     resolution: {integrity: sha512-nExy+fDCBEgqblasfeE3aQ3NuafBUxZxgxXcYfzYRZFHdVvk5q60KhCSkG0noHgHRo/xQ/BOzURLZAafFpTkmQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: false
 
   /@typescript-eslint/typescript-estree/5.46.1_typescript@4.9.4:
     resolution: {integrity: sha512-j9W4t67QiNp90kh5Nbr1w92wzt+toiIsaVPnEblB2Ih2U9fqBTyqV9T3pYWZBRt6QoMh/zVWP59EpuCjc4VRBg==}
@@ -8850,7 +8849,6 @@ packages:
       typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/utils/5.46.1_ehfyfk7qbmgzg5nk6xmobqdh3a:
     resolution: {integrity: sha512-RBdBAGv3oEpFojaCYT4Ghn4775pdjvwfDOfQ2P6qzNVgQOVrnSPe5/Pb88kv7xzYQjoio0eKHKB9GJ16ieSxvA==}
@@ -8957,7 +8955,6 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.54.0
       eslint-visitor-keys: 3.3.0
-    dev: false
 
   /@uiw/codemirror-extensions-basic-setup/4.19.7_xcbtxymuwicixsrdklqkmd5eui:
     resolution: {integrity: sha512-pk0JTFJAZOGxouBB1pdBtb59qKibO9DW4hER4VSFGBGW3TBDeXUwL/gKujhRpySHG2MtG09cgt4a3XOFIWwXTw==}
@@ -9281,6 +9278,14 @@ packages:
       chai: 4.3.7
     dev: true
 
+  /@vitest/expect/0.29.2:
+    resolution: {integrity: sha512-wjrdHB2ANTch3XKRhjWZN0UueFocH0cQbi2tR5Jtq60Nb3YOSmakjdAvUa2JFBu/o8Vjhj5cYbcMXkZxn1NzmA==}
+    dependencies:
+      '@vitest/spy': 0.29.2
+      '@vitest/utils': 0.29.2
+      chai: 4.3.7
+    dev: true
+
   /@vitest/runner/0.28.3:
     resolution: {integrity: sha512-P0qYbATaemy1midOLkw7qf8jraJszCoEvjQOSlseiXZyEDaZTZ50J+lolz2hWiWv6RwDu1iNseL9XLsG0Jm2KQ==}
     dependencies:
@@ -9297,6 +9302,14 @@ packages:
       pathe: 1.1.0
     dev: true
 
+  /@vitest/runner/0.29.2:
+    resolution: {integrity: sha512-A1P65f5+6ru36AyHWORhuQBJrOOcmDuhzl5RsaMNFe2jEkoj0faEszQS4CtPU/LxUYVIazlUtZTY0OEZmyZBnA==}
+    dependencies:
+      '@vitest/utils': 0.29.2
+      p-limit: 4.0.0
+      pathe: 1.1.0
+    dev: true
+
   /@vitest/spy/0.28.3:
     resolution: {integrity: sha512-jULA6suS6CCr9VZfr7/9x97pZ0hC55prnUNHNrg5/q16ARBY38RsjsfhuUXt6QOwvIN3BhSS0QqPzyh5Di8g6w==}
     dependencies:
@@ -9305,6 +9318,12 @@ packages:
 
   /@vitest/spy/0.28.5:
     resolution: {integrity: sha512-7if6rsHQr9zbmvxN7h+gGh2L9eIIErgf8nSKYDlg07HHimCxp4H6I/X/DPXktVPPLQfiZ1Cw2cbDIx9fSqDjGw==}
+    dependencies:
+      tinyspy: 1.1.1
+    dev: true
+
+  /@vitest/spy/0.29.2:
+    resolution: {integrity: sha512-Hc44ft5kaAytlGL2PyFwdAsufjbdOvHklwjNy/gy/saRbg9Kfkxfh+PklLm1H2Ib/p586RkQeNFKYuJInUssyw==}
     dependencies:
       tinyspy: 1.1.1
     dev: true
@@ -9321,6 +9340,16 @@ packages:
 
   /@vitest/utils/0.28.5:
     resolution: {integrity: sha512-UyZdYwdULlOa4LTUSwZ+Paz7nBHGTT72jKwdFSV4IjHF1xsokp+CabMdhjvVhYwkLfO88ylJT46YMilnkSARZA==}
+    dependencies:
+      cli-truncate: 3.1.0
+      diff: 5.1.0
+      loupe: 2.3.6
+      picocolors: 1.0.0
+      pretty-format: 27.5.1
+    dev: true
+
+  /@vitest/utils/0.29.2:
+    resolution: {integrity: sha512-F14/Uc+vCdclStS2KEoXJlOLAEyqRhnw0gM27iXw9bMTcyKRPJrQ+rlC6XZ125GIPvvKYMPpVxNhiou6PsEeYQ==}
     dependencies:
       cli-truncate: 3.1.0
       diff: 5.1.0
@@ -13970,13 +13999,13 @@ packages:
       regexpp: 3.2.0
     dev: true
 
-  /eslint-plugin-es/3.0.1_eslint@8.34.0:
+  /eslint-plugin-es/3.0.1_eslint@8.35.0:
     resolution: {integrity: sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==}
     engines: {node: '>=8.10.0'}
     peerDependencies:
       eslint: '>=4.19.1'
     dependencies:
-      eslint: 8.34.0
+      eslint: 8.35.0
       eslint-utils: 2.1.0
       regexpp: 3.2.0
     dev: true
@@ -14140,14 +14169,14 @@ packages:
       semver: 6.3.0
     dev: true
 
-  /eslint-plugin-node/11.1.0_eslint@8.34.0:
+  /eslint-plugin-node/11.1.0_eslint@8.35.0:
     resolution: {integrity: sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==}
     engines: {node: '>=8.10.0'}
     peerDependencies:
       eslint: '>=5.16.0'
     dependencies:
-      eslint: 8.34.0
-      eslint-plugin-es: 3.0.1_eslint@8.34.0
+      eslint: 8.35.0
+      eslint-plugin-es: 3.0.1_eslint@8.35.0
       eslint-utils: 2.1.0
       ignore: 5.2.0
       minimatch: 3.1.2
@@ -14221,21 +14250,12 @@ packages:
       string.prototype.matchall: 4.0.8
     dev: true
 
-  /eslint-plugin-simple-import-sort/10.0.0_eslint@8.34.0:
-    resolution: {integrity: sha512-AeTvO9UCMSNzIHRkg8S6c3RPy5YEwKWSQPx3DYghLedo2ZQxowPFLGDN1AZ2evfg6r6mjBSZSLxLFsWSu3acsw==}
-    peerDependencies:
-      eslint: '>=5.0.0'
-    dependencies:
-      eslint: 8.34.0
-    dev: true
-
   /eslint-plugin-simple-import-sort/10.0.0_eslint@8.35.0:
     resolution: {integrity: sha512-AeTvO9UCMSNzIHRkg8S6c3RPy5YEwKWSQPx3DYghLedo2ZQxowPFLGDN1AZ2evfg6r6mjBSZSLxLFsWSu3acsw==}
     peerDependencies:
       eslint: '>=5.0.0'
     dependencies:
       eslint: 8.35.0
-    dev: false
 
   /eslint-plugin-svelte3/4.0.0_dbthnr4b2bdkhyiebwn7su3hnq:
     resolution: {integrity: sha512-OIx9lgaNzD02+MDFNLw0GEUbuovNcglg+wnd/UY0fbZmlQSz7GlQiQ1f+yX0XvC07XPcDOnFcichqI3xCwp71g==}
@@ -14328,7 +14348,6 @@ packages:
     dependencies:
       eslint: 8.35.0
       eslint-visitor-keys: 2.1.0
-    dev: false
 
   /eslint-visitor-keys/1.3.0:
     resolution: {integrity: sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==}
@@ -14534,7 +14553,6 @@ packages:
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /esm-env/1.0.0:
     resolution: {integrity: sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==}
@@ -15473,7 +15491,7 @@ packages:
     resolution: {integrity: sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==}
     dependencies:
       inherits: 2.0.4
-      readable-stream: 2.3.7
+      readable-stream: 2.3.8
 
   /fs-constants/1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -16055,6 +16073,11 @@ packages:
 
   /groq/3.4.0:
     resolution: {integrity: sha512-x1ba7zNLHOcuj83JkXMge9H0uD7W3ZVNSDuLgympoOdVDYCOafS3gwmd/z4rVH7sOCxO7DtbUmyrbCW+aA5N+A==}
+    engines: {node: '>=14'}
+    dev: false
+
+  /groq/3.5.0:
+    resolution: {integrity: sha512-ewaCMW9Vj9nuVgt7ymwK+WfIQ+wmN4dDbczESo6A+hv1k05DdPc37zmTRqojiu5uYeI2GK03d64XGaN1xybSzg==}
     engines: {node: '>=14'}
     dev: false
 
@@ -19659,7 +19682,7 @@ packages:
       acorn: 8.8.2
       pathe: 1.1.0
       pkg-types: 1.0.2
-      ufo: 1.1.0
+      ufo: 1.1.1
     dev: true
 
   /module-alias/2.2.2:
@@ -22483,6 +22506,17 @@ packages:
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
 
+  /readable-stream/2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
   /readable-stream/3.6.0:
     resolution: {integrity: sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==}
     engines: {node: '>= 6'}
@@ -23172,7 +23206,6 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
-    dev: false
 
   /rsvp/4.8.5:
     resolution: {integrity: sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==}
@@ -25295,7 +25328,7 @@ packages:
   /through2/2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
     dependencies:
-      readable-stream: 2.3.7
+      readable-stream: 2.3.8
       xtend: 4.0.2
 
   /through2/3.0.2:
@@ -25804,8 +25837,8 @@ packages:
     resolution: {integrity: sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==}
     dev: true
 
-  /ufo/1.1.0:
-    resolution: {integrity: sha512-LQc2s/ZDMaCN3QLpa+uzHUOQ7SdV0qgv3VBXOolQGXTaaZpIur6PwUclF5nN2hNkiTRcUugXd1zFOW3FLJ135Q==}
+  /ufo/1.1.1:
+    resolution: {integrity: sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==}
     dev: true
 
   /uglify-js/3.17.4:
@@ -26590,6 +26623,27 @@ packages:
       - terser
     dev: true
 
+  /vite-node/0.29.2_@types+node@18.14.2:
+    resolution: {integrity: sha512-5oe1z6wzI3gkvc4yOBbDBbgpiWiApvuN4P55E8OI131JGrSuo4X3SOZrNmZYo4R8Zkze/dhi572blX0zc+6SdA==}
+    engines: {node: '>=v14.16.0'}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4
+      mlly: 1.1.1
+      pathe: 1.1.0
+      picocolors: 1.0.0
+      vite: 4.1.4_@types+node@18.14.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
   /vite-plugin-dts/1.7.1_vite@4.0.4:
     resolution: {integrity: sha512-2oGMnAjcrZN7jM1TloiS1b1mCn42s3El04ix2RFhId5P1WfMigF8WAwsqT6a6jk0Yso8t7AeZsBkkxYShR0hBQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -26809,6 +26863,40 @@ packages:
       fsevents: 2.3.2
     dev: false
 
+  /vite/4.1.4_@types+node@18.14.2:
+    resolution: {integrity: sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 18.14.2
+      esbuild: 0.16.17
+      postcss: 8.4.21
+      resolve: 1.22.1
+      rollup: 3.17.3
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
   /vitefu/0.2.4_vite@4.1.2:
     resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
     peerDependencies:
@@ -26936,61 +27024,6 @@ packages:
       - terser
     dev: true
 
-  /vitest/0.28.5:
-    resolution: {integrity: sha512-pyCQ+wcAOX7mKMcBNkzDwEHRGqQvHUl0XnoHR+3Pb1hytAHISgSxv9h0gUiSiYtISXUU3rMrKiKzFYDrI6ZIHA==}
-    engines: {node: '>=v14.16.0'}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@vitest/browser': '*'
-      '@vitest/ui': '*'
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-    dependencies:
-      '@types/chai': 4.3.4
-      '@types/chai-subset': 1.3.3
-      '@types/node': 18.14.0
-      '@vitest/expect': 0.28.5
-      '@vitest/runner': 0.28.5
-      '@vitest/spy': 0.28.5
-      '@vitest/utils': 0.28.5
-      acorn: 8.8.2
-      acorn-walk: 8.2.0
-      cac: 6.7.14
-      chai: 4.3.7
-      debug: 4.3.4
-      local-pkg: 0.4.3
-      pathe: 1.1.0
-      picocolors: 1.0.0
-      source-map: 0.6.1
-      std-env: 3.3.2
-      strip-literal: 1.0.1
-      tinybench: 2.3.1
-      tinypool: 0.3.1
-      tinyspy: 1.1.1
-      vite: 4.1.2_@types+node@18.14.0
-      vite-node: 0.28.5_@types+node@18.14.0
-      why-is-node-running: 2.2.2
-    transitivePeerDependencies:
-      - less
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
-
   /vitest/0.28.5_jsdom@20.0.3:
     resolution: {integrity: sha512-pyCQ+wcAOX7mKMcBNkzDwEHRGqQvHUl0XnoHR+3Pb1hytAHISgSxv9h0gUiSiYtISXUU3rMrKiKzFYDrI6ZIHA==}
     engines: {node: '>=v14.16.0'}
@@ -27037,6 +27070,61 @@ packages:
       tinyspy: 1.1.1
       vite: 4.1.2_@types+node@18.14.0
       vite-node: 0.28.5_@types+node@18.14.0
+      why-is-node-running: 2.2.2
+    transitivePeerDependencies:
+      - less
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vitest/0.29.2:
+    resolution: {integrity: sha512-ydK9IGbAvoY8wkg29DQ4ivcVviCaUi3ivuPKfZEVddMTenFHUfB8EEDXQV8+RasEk1ACFLgMUqAaDuQ/Nk+mQA==}
+    engines: {node: '>=v14.16.0'}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@vitest/browser': '*'
+      '@vitest/ui': '*'
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/chai': 4.3.4
+      '@types/chai-subset': 1.3.3
+      '@types/node': 18.14.2
+      '@vitest/expect': 0.29.2
+      '@vitest/runner': 0.29.2
+      '@vitest/spy': 0.29.2
+      '@vitest/utils': 0.29.2
+      acorn: 8.8.2
+      acorn-walk: 8.2.0
+      cac: 6.7.14
+      chai: 4.3.7
+      debug: 4.3.4
+      local-pkg: 0.4.3
+      pathe: 1.1.0
+      picocolors: 1.0.0
+      source-map: 0.6.1
+      std-env: 3.3.2
+      strip-literal: 1.0.1
+      tinybench: 2.3.1
+      tinypool: 0.3.1
+      tinyspy: 1.1.1
+      vite: 4.1.4_@types+node@18.14.2
+      vite-node: 0.29.2_@types+node@18.14.2
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,7 +69,7 @@ importers:
     dependencies:
       '@raulmelo/sanity-core': link:../../packages/sanity-core
       '@sanity/client': 5.2.1
-      '@sanity/vision': 3.4.0_6s5bknaubhoec4q4gecpxwo76e
+      '@sanity/vision': 3.4.0_ywmsopb22zxkrxg36znnfelhzq
       '@tabler/icons-svelte': 2.4.0_svelte@3.55.1
       '@xstate/cli': 0.4.2_prettier@2.8.4
       '@xstate/svelte': 2.0.1_mt3qdrckwv5sba7rbjbtvh5rje
@@ -80,7 +80,7 @@ importers:
       lodash.clonedeep: 4.5.0
       react: 18.2.0
       sanity: 3.4.0_2zpt4ilzykmne4yndyzrqd4gdm
-      sanity-plugin-media: 2.0.5_rlhqicyhtx472gnzii6thmn2zu
+      sanity-plugin-media: 2.0.5_jema4j64tjeydeo632aqr5eb5u
       uuid: 9.0.0
       xstate: 4.36.0
       zod: 3.20.6
@@ -101,8 +101,8 @@ importers:
       prettier: 2.8.4
       prettier-plugin-svelte: 2.9.0_jrsxveqmsx2uadbqiuq74wlc4u
       svelte: 3.55.1
-      svelte-check: 3.0.3_ai7ho4f4i6zaydnhslsjkc5xuu
-      svelte-preprocess: 5.0.1_wluf2ob37pj6ulfkqvmfgq24j4
+      svelte-check: 3.0.3_ts33rtakoomyt72aqfijsj6l7q
+      svelte-preprocess: 5.0.1_m73f5j6cepbqagrf7exwnq7j5a
       tailwindcss: 3.2.7_postcss@8.4.21
       tslib: 2.5.0
       typescript: 4.9.5
@@ -224,7 +224,7 @@ importers:
       framer-motion: 7.7.2_biqbaboplfbrettd7655fr4n2y
       lodash.omit: 4.5.0
       lodash.throttle: 4.1.1
-      next: 13.0.7_pjwopsidmaokadturxaafygjp4
+      next: 13.0.7_6m24vuloj5ihw4zc5lbsktc4fu
       next-seo: 5.15.0_gvvct4imq5upoiloat43sswrza
       query-string: 8.0.3
       react: 18.2.0
@@ -237,7 +237,7 @@ importers:
       smoothscroll-polyfill: 0.4.4
       xstate: 4.35.0
     devDependencies:
-      '@babel/eslint-parser': 7.19.1_ydmbqfus77qykiqxhcwsorsqbq
+      '@babel/eslint-parser': 7.19.1_zt6cfucldurvbyn2isj445jria
       '@next/bundle-analyzer': 13.0.7
       '@testing-library/jest-dom': 5.16.5
       '@testing-library/react': 13.4.0_biqbaboplfbrettd7655fr4n2y
@@ -248,11 +248,11 @@ importers:
       '@types/react': 18.0.26
       '@types/react-dom': 18.0.9
       '@types/react-instantsearch-dom': 6.12.3
-      '@typescript-eslint/eslint-plugin': 5.46.1_2facupdxlvm55gtp63dnpqcawi
+      '@typescript-eslint/eslint-plugin': 5.46.1_jfexnejfvdoaivzgwqqlsbumnu
       '@xstate/cli': 0.4.1_prettier@2.8.1
       autoprefixer: 10.4.13_postcss@8.4.21
       duplicate-package-checker-webpack-plugin: 3.0.0
-      eslint-config-next: 13.0.7_ehfyfk7qbmgzg5nk6xmobqdh3a
+      eslint-config-next: 13.0.7_ddvlikdjy3uujmudifwl7fbpl4
       jest: 29.3.1
       jest-environment-jsdom: 29.3.1
       next-compose-plugins: 2.2.1
@@ -364,7 +364,7 @@ importers:
       '@types/flat': 5.0.2
       '@types/lodash.defaultsdeep': 4.6.7
       '@types/negotiator': 0.6.1
-      '@xstate/cli': 0.4.2_prettier@2.8.1
+      '@xstate/cli': 0.4.2_prettier@2.8.4
 
   apps/website-remix:
     specifiers:
@@ -435,7 +435,7 @@ importers:
       '@remix-run/react': 1.11.1_biqbaboplfbrettd7655fr4n2y
       '@remix-run/vercel': 1.11.1_ivg4iubcgjfcvyvmo3o4qzd3pe
       '@sanity/client': 4.0.1
-      '@sanity/vision': 3.2.4_6s5bknaubhoec4q4gecpxwo76e
+      '@sanity/vision': 3.2.4_ywmsopb22zxkrxg36znnfelhzq
       '@vercel/node': 2.8.15
       '@xstate/react': 3.0.2_esdfnfzm4b7belpkp5miw2a4kq
       accept-language-parser: 1.5.0
@@ -454,7 +454,7 @@ importers:
       react-use: 17.4.0_biqbaboplfbrettd7655fr4n2y
       remix-utils: 6.0.0_apaet52cvypgx77ydu3qow6dwu
       sanity: 3.2.4_twemhiufzrfjqacw3yktt6ldfm
-      sanity-plugin-media: 2.0.3_tmfdlqcpexmyewdphhqgtauxrq
+      sanity-plugin-media: 2.0.3_7u6irrow7qvib7pa4fye3jzaqq
       schema-dts: 1.1.0_typescript@4.9.4
       tiny-invariant: 1.3.1
       xstate: 4.35.2
@@ -619,12 +619,12 @@ importers:
       '@popperjs/core': 2.11.6
       '@raulmelo/styles': link:../styles
       '@storybook/addon-actions': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/addon-essentials': 6.5.16_qfg2oyphijmbfyorruyfikzjbu
+      '@storybook/addon-essentials': 6.5.16_grb24zorjb6ghupi76c2w3qx4u
       '@storybook/addon-links': 6.5.16_biqbaboplfbrettd7655fr4n2y
       '@storybook/addon-postcss': 2.0.0_webpack@5.75.0
       '@storybook/builder-webpack5': 6.5.16_o4scbtliisanygemawej7x2d6i
       '@storybook/manager-webpack5': 6.5.16_o4scbtliisanygemawej7x2d6i
-      '@storybook/react': 6.5.16_dpfgtf3aew22p6fuhy7t4xrcb4
+      '@storybook/react': 6.5.16_4nfcraixckxvlsvnxdksc45hzi
       '@testing-library/jest-dom': 5.16.5
       '@testing-library/react': 13.4.0_biqbaboplfbrettd7655fr4n2y
       '@types/react': 18.0.27
@@ -1132,16 +1132,16 @@ packages:
       semver: 6.3.0
     dev: true
 
-  /@babel/eslint-parser/7.19.1_ydmbqfus77qykiqxhcwsorsqbq:
+  /@babel/eslint-parser/7.19.1_zt6cfucldurvbyn2isj445jria:
     resolution: {integrity: sha512-AqNf2QWt1rtu2/1rLswy6CDP7H9Oh3mMhk177Y67Rg8d7RD9WfOLLv8CGn6tisFvS2htm86yIe1yLF6I1UDaGQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
     peerDependencies:
       '@babel/core': '>=7.11.0'
       eslint: ^7.5.0 || ^8.0.0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 8.34.0
+      eslint: 8.35.0
       eslint-visitor-keys: 2.1.0
       semver: 6.3.0
     dev: true
@@ -1253,13 +1253,32 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/helper-create-regexp-features-plugin/7.20.5_@babel+core@7.20.12:
+  /@babel/helper-create-class-features-plugin/7.20.12_@babel+core@7.21.0:
+    resolution: {integrity: sha512-9OunRkbT0JQcednL0UFvbfXpAsUXiGjUk0a7sN8fUXX7Mue79cUSMjHGDRRi/Vz9vYlpIhLV5fMD5dKoMhhsNQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-member-expression-to-functions': 7.20.7
+      '@babel/helper-optimise-call-expression': 7.18.6
+      '@babel/helper-replace-supers': 7.20.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
+      '@babel/helper-split-export-declaration': 7.18.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/helper-create-regexp-features-plugin/7.20.5_@babel+core@7.21.0:
     resolution: {integrity: sha512-m68B1lkg3XDGX5yCvGO0kPx3v9WIYLnzjKfPcQiwntEQa5ZeRkPmo2X/ISJc8qxWGfwUr+kvZAeEzAwLec2r2w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-annotate-as-pure': 7.18.6
       regexpu-core: 5.2.2
     dev: true
@@ -1282,13 +1301,13 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/helper-define-polyfill-provider/0.3.3_@babel+core@7.20.12:
+  /@babel/helper-define-polyfill-provider/0.3.3_@babel+core@7.21.0:
     resolution: {integrity: sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==}
     peerDependencies:
       '@babel/core': ^7.4.0-0
     dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.12
+      '@babel/core': 7.21.0
+      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.21.0
       '@babel/helper-plugin-utils': 7.20.2
       debug: 4.3.4
       lodash.debounce: 4.0.8
@@ -1403,13 +1422,13 @@ packages:
     resolution: {integrity: sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/helper-remap-async-to-generator/7.18.9_@babel+core@7.20.12:
+  /@babel/helper-remap-async-to-generator/7.18.9_@babel+core@7.21.0:
     resolution: {integrity: sha512-dI7q50YKd8BAv3VEfgg7PS7yD3Rtbi2J1XMXaalXO0W0164hYLnh8zpjRS0mte9MfVp/tltvr/cfdXPvJr1opA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-wrap-function': 7.20.5
@@ -1520,6 +1539,7 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.20.7
+    dev: true
 
   /@babel/parser/7.20.15:
     resolution: {integrity: sha512-DI4a1oZuf8wC+oAJA9RW6ga3Zbe8RZFt7kD9i4qAspz3I/yHet1VvC3DiSy/fsUvv5pvJuNPh0LPOdCcqinDPg==}
@@ -1543,39 +1563,39 @@ packages:
     dependencies:
       '@babel/types': 7.21.2
 
-  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.18.6_@babel+core@7.20.12:
+  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.18.6_@babel+core@7.21.0:
     resolution: {integrity: sha512-Dgxsyg54Fx1d4Nge8UnvTrED63vrwOdPmyvPzlNN/boaliRP54pm3pGzZD1SJUwrBA+Cs/xdG8kXX6Mn/RfISQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.20.7_@babel+core@7.20.12:
+  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/7.20.7_@babel+core@7.21.0:
     resolution: {integrity: sha512-sbr9+wNE5aXMBBFBICk01tt7sBf2Oc9ikRFEcem/ZORup9IMUdNhW7/wVLEbbtlWOsEubJet46mHAL2C8+2jKQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.13.0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/plugin-proposal-optional-chaining': 7.20.7_@babel+core@7.20.12
+      '@babel/plugin-proposal-optional-chaining': 7.20.7_@babel+core@7.21.0
     dev: true
 
-  /@babel/plugin-proposal-async-generator-functions/7.20.7_@babel+core@7.20.12:
+  /@babel/plugin-proposal-async-generator-functions/7.20.7_@babel+core@7.21.0:
     resolution: {integrity: sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-remap-async-to-generator': 7.18.9_@babel+core@7.20.12
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.20.12
+      '@babel/helper-remap-async-to-generator': 7.18.9_@babel+core@7.21.0
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.21.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1587,22 +1607,35 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-create-class-features-plugin': 7.20.12_@babel+core@7.20.12
+      '@babel/helper-create-class-features-plugin': 7.20.12_@babel+core@7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-class-static-block/7.20.7_@babel+core@7.20.12:
+  /@babel/plugin-proposal-class-properties/7.18.6_@babel+core@7.21.0:
+    resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-create-class-features-plugin': 7.20.12_@babel+core@7.21.0
+      '@babel/helper-plugin-utils': 7.20.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/plugin-proposal-class-static-block/7.20.7_@babel+core@7.21.0:
     resolution: {integrity: sha512-AveGOoi9DAjUYYuUAG//Ig69GlazLnoyzMw68VCDux+c1tsnnH/OkYcpz/5xzMkEFC6UxjR5Gw1c+iY2wOGVeQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
     dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-create-class-features-plugin': 7.20.12_@babel+core@7.20.12
+      '@babel/core': 7.21.0
+      '@babel/helper-create-class-features-plugin': 7.20.12_@babel+core@7.21.0
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.20.12
+      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.21.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1623,15 +1656,15 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-dynamic-import/7.18.6_@babel+core@7.20.12:
+  /@babel/plugin-proposal-dynamic-import/7.18.6_@babel+core@7.21.0:
     resolution: {integrity: sha512-1auuwmK+Rz13SJj36R+jqFPMJWyKEDd7lLSdOj4oJK0UTgGueSAtkrCvz9ewmgyU/P941Rv2fQwZJN8s6QruXw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.20.12
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.21.0
     dev: true
 
   /@babel/plugin-proposal-export-default-from/7.18.10_@babel+core@7.20.12:
@@ -1645,37 +1678,37 @@ packages:
       '@babel/plugin-syntax-export-default-from': 7.18.6_@babel+core@7.20.12
     dev: true
 
-  /@babel/plugin-proposal-export-namespace-from/7.18.9_@babel+core@7.20.12:
+  /@babel/plugin-proposal-export-namespace-from/7.18.9_@babel+core@7.21.0:
     resolution: {integrity: sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.20.12
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.21.0
     dev: true
 
-  /@babel/plugin-proposal-json-strings/7.18.6_@babel+core@7.20.12:
+  /@babel/plugin-proposal-json-strings/7.18.6_@babel+core@7.21.0:
     resolution: {integrity: sha512-lr1peyn9kOdbYc0xr0OdHTZ5FMqS6Di+H0Fz2I/JwMzGmzJETNeOFq2pBySw6X/KFL5EWDjlJuMsUGRFb8fQgQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.20.12
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.21.0
     dev: true
 
-  /@babel/plugin-proposal-logical-assignment-operators/7.20.7_@babel+core@7.20.12:
+  /@babel/plugin-proposal-logical-assignment-operators/7.20.7_@babel+core@7.21.0:
     resolution: {integrity: sha512-y7C7cZgpMIjWlKE5T7eJwp+tnRYM89HmRvWM5EQuB5BoHEONjmQ8lSNmBUwOyy/GFRsohJED51YBF79hE1djug==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.20.12
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.21.0
     dev: true
 
   /@babel/plugin-proposal-nullish-coalescing-operator/7.18.6_@babel+core@7.20.12:
@@ -1686,18 +1719,29 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.20.12
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.21.0
     dev: true
 
-  /@babel/plugin-proposal-numeric-separator/7.18.6_@babel+core@7.20.12:
+  /@babel/plugin-proposal-nullish-coalescing-operator/7.18.6_@babel+core@7.21.0:
+    resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.21.0
+    dev: true
+
+  /@babel/plugin-proposal-numeric-separator/7.18.6_@babel+core@7.21.0:
     resolution: {integrity: sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.20.12
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.21.0
     dev: true
 
   /@babel/plugin-proposal-object-rest-spread/7.12.1_@babel+core@7.12.9:
@@ -1719,21 +1763,35 @@ packages:
     dependencies:
       '@babel/compat-data': 7.20.14
       '@babel/core': 7.20.12
-      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.12
+      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.21.0
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.20.12
-      '@babel/plugin-transform-parameters': 7.20.7_@babel+core@7.20.12
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.21.0
+      '@babel/plugin-transform-parameters': 7.20.7_@babel+core@7.21.0
     dev: true
 
-  /@babel/plugin-proposal-optional-catch-binding/7.18.6_@babel+core@7.20.12:
+  /@babel/plugin-proposal-object-rest-spread/7.20.7_@babel+core@7.21.0:
+    resolution: {integrity: sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/compat-data': 7.20.14
+      '@babel/core': 7.21.0
+      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.21.0
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.21.0
+      '@babel/plugin-transform-parameters': 7.20.7_@babel+core@7.21.0
+    dev: true
+
+  /@babel/plugin-proposal-optional-catch-binding/7.18.6_@babel+core@7.21.0:
     resolution: {integrity: sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.20.12
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.21.0
     dev: true
 
   /@babel/plugin-proposal-optional-chaining/7.20.7_@babel+core@7.20.12:
@@ -1745,7 +1803,19 @@ packages:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.20.12
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.21.0
+    dev: true
+
+  /@babel/plugin-proposal-optional-chaining/7.20.7_@babel+core@7.21.0:
+    resolution: {integrity: sha512-T+A7b1kfjtRM51ssoOfS1+wbyCVqorfyZhT99TvxxLMirPShD8CzKMRepMlCBGM5RpHMbn8s+5MMHnPstJH6mQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.21.0
     dev: true
 
   /@babel/plugin-proposal-private-methods/7.18.6_@babel+core@7.20.12:
@@ -1755,7 +1825,20 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-create-class-features-plugin': 7.20.12_@babel+core@7.20.12
+      '@babel/helper-create-class-features-plugin': 7.20.12_@babel+core@7.21.0
+      '@babel/helper-plugin-utils': 7.20.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/plugin-proposal-private-methods/7.18.6_@babel+core@7.21.0:
+    resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-create-class-features-plugin': 7.20.12_@babel+core@7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
@@ -1769,21 +1852,36 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-create-class-features-plugin': 7.20.12_@babel+core@7.20.12
+      '@babel/helper-create-class-features-plugin': 7.20.12_@babel+core@7.21.0
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.20.12
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.21.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-unicode-property-regex/7.18.6_@babel+core@7.20.12:
+  /@babel/plugin-proposal-private-property-in-object/7.20.5_@babel+core@7.21.0:
+    resolution: {integrity: sha512-Vq7b9dUA12ByzB4EjQTPo25sFhY+08pQDBSZRtUAkj7lb7jahaHR5igera16QZ+3my1nYR4dKsNdYj5IjPHilQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-create-class-features-plugin': 7.20.12_@babel+core@7.21.0
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.21.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/plugin-proposal-unicode-property-regex/7.18.6_@babel+core@7.21.0:
     resolution: {integrity: sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==}
     engines: {node: '>=4'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-create-regexp-features-plugin': 7.20.5_@babel+core@7.20.12
+      '@babel/core': 7.21.0
+      '@babel/helper-create-regexp-features-plugin': 7.20.5_@babel+core@7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -1793,6 +1891,15 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
+  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.21.0:
+    resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -1814,13 +1921,22 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-class-static-block/7.14.5_@babel+core@7.20.12:
+  /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.21.0:
+    resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
+  /@babel/plugin-syntax-class-static-block/7.14.5_@babel+core@7.21.0:
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -1843,6 +1959,15 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
+  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.21.0:
+    resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
   /@babel/plugin-syntax-export-default-from/7.18.6_@babel+core@7.20.12:
     resolution: {integrity: sha512-Kr//z3ujSVNx6E9z9ih5xXXMqK07VVTuqPmqGe6Mss/zW5XPeLZeSDZoP9ab/hT4wPKqAgjl2PnhPrcpk8Seew==}
     engines: {node: '>=6.9.0'}
@@ -1853,12 +1978,12 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.20.12:
+  /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.21.0:
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -1872,13 +1997,23 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-import-assertions/7.20.0_@babel+core@7.20.12:
+  /@babel/plugin-syntax-flow/7.18.6_@babel+core@7.21.0:
+    resolution: {integrity: sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
+  /@babel/plugin-syntax-import-assertions/7.20.0_@babel+core@7.21.0:
     resolution: {integrity: sha512-IUh1vakzNoWalR8ch/areW7qFopR2AEw03JlG7BbrDqmQ4X3q9uuipQwSGrUn7oGiemKjtSLDhNtQHzMHr1JdQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -1897,6 +2032,15 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
+  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.21.0:
+    resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -1926,7 +2070,6 @@ packages:
     dependencies:
       '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.20.12:
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
@@ -1934,6 +2077,15 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
+  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.21.0:
+    resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -1946,12 +2098,30 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
+  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.21.0:
+    resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
   /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.20.12:
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
+  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.21.0:
+    resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -1973,12 +2143,30 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
+  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.21.0:
+    resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
   /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.20.12:
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
+  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.21.0:
+    resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -1991,13 +2179,22 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-private-property-in-object/7.14.5_@babel+core@7.20.12:
+  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.21.0:
+    resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
+  /@babel/plugin-syntax-private-property-in-object/7.14.5_@babel+core@7.21.0:
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -2008,6 +2205,16 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
+  /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.21.0:
+    resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -2031,27 +2238,37 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-async-to-generator/7.20.7_@babel+core@7.20.12:
+  /@babel/plugin-transform-arrow-functions/7.20.7_@babel+core@7.21.0:
+    resolution: {integrity: sha512-3poA5E7dzDomxj9WXWwuD6A5F3kc7VXwIJO+E+J8qtDtS+pXPAhrgEyh+9GBwBgPq1Z+bB+/JD60lp5jsN7JPQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
+  /@babel/plugin-transform-async-to-generator/7.20.7_@babel+core@7.21.0:
     resolution: {integrity: sha512-Uo5gwHPT9vgnSXQxqGtpdufUiWp96gk7yiP4Mp5bm1QMkEmLXBO7PAGYbKoJ6DhAwiNkcHFBol/x5zZZkL/t0Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-module-imports': 7.18.6
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-remap-async-to-generator': 7.18.9_@babel+core@7.20.12
+      '@babel/helper-remap-async-to-generator': 7.18.9_@babel+core@7.21.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-block-scoped-functions/7.18.6_@babel+core@7.20.12:
+  /@babel/plugin-transform-block-scoped-functions/7.18.6_@babel+core@7.21.0:
     resolution: {integrity: sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -2065,6 +2282,16 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
+  /@babel/plugin-transform-block-scoping/7.20.14_@babel+core@7.21.0:
+    resolution: {integrity: sha512-sMPepQtsOs5fM1bwNvuJJHvaCfOEQfmc01FGw0ELlTpTJj5Ql/zuNRRldYhAPys4ghXdBIQJbRVYi44/7QflQQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
   /@babel/plugin-transform-classes/7.20.7_@babel+core@7.20.12:
     resolution: {integrity: sha512-LWYbsiXTPKl+oBlXUGlwNlJZetXD5Am+CyBdqhPsDVjM9Jc8jwBJFrKhHf900Kfk2eZG1y9MAG3UNajol7A4VQ==}
     engines: {node: '>=6.9.0'}
@@ -2073,7 +2300,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.12
+      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.21.0
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-function-name': 7.19.0
       '@babel/helper-optimise-call-expression': 7.18.6
@@ -2085,13 +2312,33 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-computed-properties/7.20.7_@babel+core@7.20.12:
+  /@babel/plugin-transform-classes/7.20.7_@babel+core@7.21.0:
+    resolution: {integrity: sha512-LWYbsiXTPKl+oBlXUGlwNlJZetXD5Am+CyBdqhPsDVjM9Jc8jwBJFrKhHf900Kfk2eZG1y9MAG3UNajol7A4VQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.21.0
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-optimise-call-expression': 7.18.6
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-replace-supers': 7.20.7
+      '@babel/helper-split-export-declaration': 7.18.6
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/plugin-transform-computed-properties/7.20.7_@babel+core@7.21.0:
     resolution: {integrity: sha512-Lz7MvBK6DTjElHAmfu6bfANzKcxpyNPeYBGEafyA6E5HtRpjpZwU+u7Qrgz/2OR0z+5TvKYbPdphfSaAcZBrYQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/template': 7.20.7
     dev: true
@@ -2106,34 +2353,44 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-dotall-regex/7.18.6_@babel+core@7.20.12:
+  /@babel/plugin-transform-destructuring/7.20.7_@babel+core@7.21.0:
+    resolution: {integrity: sha512-Xwg403sRrZb81IVB79ZPqNQME23yhugYVqgTxAhT99h485F4f+GMELFhhOsscDUB7HCswepKeCKLn/GZvUKoBA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
+  /@babel/plugin-transform-dotall-regex/7.18.6_@babel+core@7.21.0:
     resolution: {integrity: sha512-6S3jpun1eEbAxq7TdjLotAsl4WpQI9DxfkycRcKrjhQYzU87qpXdknpBg/e+TdcMehqGnLFi7tnFUBR02Vq6wg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-create-regexp-features-plugin': 7.20.5_@babel+core@7.20.12
+      '@babel/core': 7.21.0
+      '@babel/helper-create-regexp-features-plugin': 7.20.5_@babel+core@7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-duplicate-keys/7.18.9_@babel+core@7.20.12:
+  /@babel/plugin-transform-duplicate-keys/7.18.9_@babel+core@7.21.0:
     resolution: {integrity: sha512-d2bmXCtZXYc59/0SanQKbiWINadaJXqtvIQIzd4+hNwkWBgyCd5F/2t1kXoUdvPMrxzPvhK6EMQRROxsue+mfw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-exponentiation-operator/7.18.6_@babel+core@7.20.12:
+  /@babel/plugin-transform-exponentiation-operator/7.18.6_@babel+core@7.21.0:
     resolution: {integrity: sha512-wzEtc0+2c88FVR34aQmiz56dxEkxr2g8DQb/KfaFa1JYXOFVsbhvAonFN6PwVWj++fKmku8NP80plJ5Et4wqHw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.18.9
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
@@ -2149,6 +2406,17 @@ packages:
       '@babel/plugin-syntax-flow': 7.18.6_@babel+core@7.20.12
     dev: true
 
+  /@babel/plugin-transform-flow-strip-types/7.19.0_@babel+core@7.21.0:
+    resolution: {integrity: sha512-sgeMlNaQVbCSpgLSKP4ZZKfsJVnFnNQlUSk6gPYzR/q7tzCgQF2t8RBKAP6cKJeZdveei7Q7Jm527xepI8lNLg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-flow': 7.18.6_@babel+core@7.21.0
+    dev: true
+
   /@babel/plugin-transform-for-of/7.18.8_@babel+core@7.20.12:
     resolution: {integrity: sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==}
     engines: {node: '>=6.9.0'}
@@ -2159,45 +2427,55 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-function-name/7.18.9_@babel+core@7.20.12:
+  /@babel/plugin-transform-for-of/7.18.8_@babel+core@7.21.0:
+    resolution: {integrity: sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
+  /@babel/plugin-transform-function-name/7.18.9_@babel+core@7.21.0:
     resolution: {integrity: sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.12
+      '@babel/core': 7.21.0
+      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.21.0
       '@babel/helper-function-name': 7.19.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-literals/7.18.9_@babel+core@7.20.12:
+  /@babel/plugin-transform-literals/7.18.9_@babel+core@7.21.0:
     resolution: {integrity: sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-member-expression-literals/7.18.6_@babel+core@7.20.12:
+  /@babel/plugin-transform-member-expression-literals/7.18.6_@babel+core@7.21.0:
     resolution: {integrity: sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-modules-amd/7.20.11_@babel+core@7.20.12:
+  /@babel/plugin-transform-modules-amd/7.20.11_@babel+core@7.21.0:
     resolution: {integrity: sha512-NuzCt5IIYOW0O30UvqktzHYR2ud5bOWbY0yaxWZ6G+aFzOMJvrs5YHNikrbdaT15+KNO31nPOy5Fim3ku6Zb5g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-module-transforms': 7.20.11
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
@@ -2218,13 +2496,27 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-modules-systemjs/7.20.11_@babel+core@7.20.12:
+  /@babel/plugin-transform-modules-commonjs/7.20.11_@babel+core@7.21.0:
+    resolution: {integrity: sha512-S8e1f7WQ7cimJQ51JkAaDrEtohVEitXjgCGAS2N8S31Y42E+kWwfSz83LYz57QdBm7q9diARVqanIaH2oVgQnw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-module-transforms': 7.20.11
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-simple-access': 7.20.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/plugin-transform-modules-systemjs/7.20.11_@babel+core@7.21.0:
     resolution: {integrity: sha512-vVu5g9BPQKSFEmvt2TA4Da5N+QVS66EX21d8uoOihC+OCpUoGvzVsXeqFdtAEfVa5BILAeFt+U7yVmLbQnAJmw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-module-transforms': 7.20.11
       '@babel/helper-plugin-utils': 7.20.2
@@ -2233,47 +2525,47 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-modules-umd/7.18.6_@babel+core@7.20.12:
+  /@babel/plugin-transform-modules-umd/7.18.6_@babel+core@7.21.0:
     resolution: {integrity: sha512-dcegErExVeXcRqNtkRU/z8WlBLnvD4MRnHgNs3MytRO1Mn1sHRyhbcpYbVMGclAqOjdW+9cfkdZno9dFdfKLfQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-module-transforms': 7.20.11
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-named-capturing-groups-regex/7.20.5_@babel+core@7.20.12:
+  /@babel/plugin-transform-named-capturing-groups-regex/7.20.5_@babel+core@7.21.0:
     resolution: {integrity: sha512-mOW4tTzi5iTLnw+78iEq3gr8Aoq4WNRGpmSlrogqaiCBoR1HFhpU4JkpQFOHfeYx3ReVIFWOQJS4aZBRvuZ6mA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-create-regexp-features-plugin': 7.20.5_@babel+core@7.20.12
+      '@babel/core': 7.21.0
+      '@babel/helper-create-regexp-features-plugin': 7.20.5_@babel+core@7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-new-target/7.18.6_@babel+core@7.20.12:
+  /@babel/plugin-transform-new-target/7.18.6_@babel+core@7.21.0:
     resolution: {integrity: sha512-DjwFA/9Iu3Z+vrAn+8pBUGcjhxKguSMlsFqeCKbhb9BAV756v0krzVK04CRDi/4aqmk8BsHb4a/gFcaA5joXRw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-object-super/7.18.6_@babel+core@7.20.12:
+  /@babel/plugin-transform-object-super/7.18.6_@babel+core@7.21.0:
     resolution: {integrity: sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-replace-supers': 7.20.7
     transitivePeerDependencies:
@@ -2300,13 +2592,23 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-property-literals/7.18.6_@babel+core@7.20.12:
+  /@babel/plugin-transform-parameters/7.20.7_@babel+core@7.21.0:
+    resolution: {integrity: sha512-WiWBIkeHKVOSYPO0pWkxGPfKeWrCJyD3NJ53+Lrp/QMSZbsVPovrVl2aWZ19D/LTVnaDv5Ap7GJ/B2CTOZdrfA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
+  /@babel/plugin-transform-property-literals/7.18.6_@babel+core@7.21.0:
     resolution: {integrity: sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -2320,6 +2622,16 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
+  /@babel/plugin-transform-react-display-name/7.18.6_@babel+core@7.21.0:
+    resolution: {integrity: sha512-TV4sQ+T013n61uMoygyMRm+xf04Bd5oqFpv2jAEQwSZ8NwQA7zeRPg1LMVg2PWi3zWBz+CLKD+v5bcpZ/BS0aA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
   /@babel/plugin-transform-react-jsx-development/7.18.6_@babel+core@7.20.12:
     resolution: {integrity: sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==}
     engines: {node: '>=6.9.0'}
@@ -2328,6 +2640,16 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/plugin-transform-react-jsx': 7.20.13_@babel+core@7.20.12
+    dev: true
+
+  /@babel/plugin-transform-react-jsx-development/7.18.6_@babel+core@7.21.0:
+    resolution: {integrity: sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/plugin-transform-react-jsx': 7.20.13_@babel+core@7.21.0
     dev: true
 
   /@babel/plugin-transform-react-jsx-self/7.18.6_@babel+core@7.20.12:
@@ -2363,6 +2685,20 @@ packages:
       '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.20.12
       '@babel/types': 7.20.7
 
+  /@babel/plugin-transform-react-jsx/7.20.13_@babel+core@7.21.0:
+    resolution: {integrity: sha512-MmTZx/bkUrfJhhYAYt3Urjm+h8DQGrPrnKQ94jLo7NLuOU+T89a7IByhKmrb8SKhrIYIQ0FN0CHMbnFRen4qNw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.21.0
+      '@babel/types': 7.20.7
+    dev: true
+
   /@babel/plugin-transform-react-jsx/7.21.0_@babel+core@7.21.0:
     resolution: {integrity: sha512-6OAWljMvQrZjR2DaNhVfRz6dkCAVV+ymcLUmaf8bccGOHn2v5rHJK3tTpij0BuhdYWP4LLaqj5lwcdlpAAPuvg==}
     engines: {node: '>=6.9.0'}
@@ -2388,24 +2724,35 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-regenerator/7.20.5_@babel+core@7.20.12:
+  /@babel/plugin-transform-react-pure-annotations/7.18.6_@babel+core@7.21.0:
+    resolution: {integrity: sha512-I8VfEPg9r2TRDdvnHgPepTKvuRomzA8+u+nhY7qSI1fR2hRNebasZEETLyM5mAUr0Ku56OkXJ0I7NHJnO6cJiQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
+  /@babel/plugin-transform-regenerator/7.20.5_@babel+core@7.21.0:
     resolution: {integrity: sha512-kW/oO7HPBtntbsahzQ0qSE3tFvkFwnbozz3NWFhLGqH75vLEg+sCGngLlhVkePlCs3Jv0dBBHDzCHxNiFAQKCQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
       regenerator-transform: 0.15.1
     dev: true
 
-  /@babel/plugin-transform-reserved-words/7.18.6_@babel+core@7.20.12:
+  /@babel/plugin-transform-reserved-words/7.18.6_@babel+core@7.21.0:
     resolution: {integrity: sha512-oX/4MyMoypzHjFrT1CdivfKZ+XvIPMFXwwxHp/r0Ddy2Vuomt4HDFGmft1TAY2yiTKiNSsh3kjBAzcM8kSdsjA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -2416,6 +2763,16 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
+  /@babel/plugin-transform-shorthand-properties/7.18.6_@babel+core@7.21.0:
+    resolution: {integrity: sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -2430,13 +2787,24 @@ packages:
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
     dev: true
 
-  /@babel/plugin-transform-sticky-regex/7.18.6_@babel+core@7.20.12:
+  /@babel/plugin-transform-spread/7.20.7_@babel+core@7.21.0:
+    resolution: {integrity: sha512-ewBbHQ+1U/VnH1fxltbJqDeWBU1oNLG8Dj11uIv3xVf7nrQu0bPGe5Rf716r7K5Qz+SqtAOVswoVunoiBtGhxw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
+    dev: true
+
+  /@babel/plugin-transform-sticky-regex/7.18.6_@babel+core@7.21.0:
     resolution: {integrity: sha512-kfiDrDQ+PBsQDO85yj1icueWMfGfJFKN1KCkndygtu/C9+XUfydLC8Iv5UYJqRwy4zk8EcplRxEOeLyjq1gm6Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -2450,13 +2818,23 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-typeof-symbol/7.18.9_@babel+core@7.20.12:
+  /@babel/plugin-transform-template-literals/7.18.9_@babel+core@7.21.0:
+    resolution: {integrity: sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
+  /@babel/plugin-transform-typeof-symbol/7.18.9_@babel+core@7.21.0:
     resolution: {integrity: sha512-SRfwTtF11G2aemAZWivL7PD+C9z52v9EvMqH9BuYbabyPuKUvSWks3oCg6041pT925L4zVFqaVBeECwsmlguEw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -2474,24 +2852,24 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-unicode-escapes/7.18.10_@babel+core@7.20.12:
+  /@babel/plugin-transform-unicode-escapes/7.18.10_@babel+core@7.21.0:
     resolution: {integrity: sha512-kKAdAI+YzPgGY/ftStBFXTI1LZFju38rYThnfMykS+IXy8BVx+res7s2fxf1l8I35DV2T97ezo6+SGrXz6B3iQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-unicode-regex/7.18.6_@babel+core@7.20.12:
+  /@babel/plugin-transform-unicode-regex/7.18.6_@babel+core@7.21.0:
     resolution: {integrity: sha512-gE7A6Lt7YLnNOL3Pb9BNeZvi+d8l7tcRrG4+pwJjK9hD2xX4mEvjlQW60G9EEmfXVYRPv9VRQcyegIVHCql/AA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-create-regexp-features-plugin': 7.20.5_@babel+core@7.20.12
+      '@babel/core': 7.21.0
+      '@babel/helper-create-regexp-features-plugin': 7.20.5_@babel+core@7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -2503,78 +2881,164 @@ packages:
     dependencies:
       '@babel/compat-data': 7.20.14
       '@babel/core': 7.20.12
-      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.12
+      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.21.0
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-validator-option': 7.18.6
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.20.7_@babel+core@7.20.12
-      '@babel/plugin-proposal-async-generator-functions': 7.20.7_@babel+core@7.20.12
-      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-proposal-class-static-block': 7.20.7_@babel+core@7.20.12
-      '@babel/plugin-proposal-dynamic-import': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-proposal-export-namespace-from': 7.18.9_@babel+core@7.20.12
-      '@babel/plugin-proposal-json-strings': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-proposal-logical-assignment-operators': 7.20.7_@babel+core@7.20.12
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-proposal-numeric-separator': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-proposal-object-rest-spread': 7.20.7_@babel+core@7.20.12
-      '@babel/plugin-proposal-optional-catch-binding': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-proposal-optional-chaining': 7.20.7_@babel+core@7.20.12
-      '@babel/plugin-proposal-private-methods': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-proposal-private-property-in-object': 7.20.5_@babel+core@7.20.12
-      '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.20.12
-      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.20.12
-      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.20.12
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.20.12
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.20.12
-      '@babel/plugin-syntax-import-assertions': 7.20.0_@babel+core@7.20.12
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.20.12
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.20.12
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.20.12
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.20.12
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.20.12
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.20.12
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.20.12
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.20.12
-      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.20.12
-      '@babel/plugin-transform-arrow-functions': 7.20.7_@babel+core@7.20.12
-      '@babel/plugin-transform-async-to-generator': 7.20.7_@babel+core@7.20.12
-      '@babel/plugin-transform-block-scoped-functions': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-block-scoping': 7.20.14_@babel+core@7.20.12
-      '@babel/plugin-transform-classes': 7.20.7_@babel+core@7.20.12
-      '@babel/plugin-transform-computed-properties': 7.20.7_@babel+core@7.20.12
-      '@babel/plugin-transform-destructuring': 7.20.7_@babel+core@7.20.12
-      '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-duplicate-keys': 7.18.9_@babel+core@7.20.12
-      '@babel/plugin-transform-exponentiation-operator': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-for-of': 7.18.8_@babel+core@7.20.12
-      '@babel/plugin-transform-function-name': 7.18.9_@babel+core@7.20.12
-      '@babel/plugin-transform-literals': 7.18.9_@babel+core@7.20.12
-      '@babel/plugin-transform-member-expression-literals': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-modules-amd': 7.20.11_@babel+core@7.20.12
-      '@babel/plugin-transform-modules-commonjs': 7.20.11_@babel+core@7.20.12
-      '@babel/plugin-transform-modules-systemjs': 7.20.11_@babel+core@7.20.12
-      '@babel/plugin-transform-modules-umd': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.20.5_@babel+core@7.20.12
-      '@babel/plugin-transform-new-target': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-object-super': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-parameters': 7.20.7_@babel+core@7.20.12
-      '@babel/plugin-transform-property-literals': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-regenerator': 7.20.5_@babel+core@7.20.12
-      '@babel/plugin-transform-reserved-words': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-shorthand-properties': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-spread': 7.20.7_@babel+core@7.20.12
-      '@babel/plugin-transform-sticky-regex': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.20.12
-      '@babel/plugin-transform-typeof-symbol': 7.18.9_@babel+core@7.20.12
-      '@babel/plugin-transform-unicode-escapes': 7.18.10_@babel+core@7.20.12
-      '@babel/plugin-transform-unicode-regex': 7.18.6_@babel+core@7.20.12
-      '@babel/preset-modules': 0.1.5_@babel+core@7.20.12
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-proposal-async-generator-functions': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-proposal-class-static-block': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-proposal-dynamic-import': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-proposal-export-namespace-from': 7.18.9_@babel+core@7.21.0
+      '@babel/plugin-proposal-json-strings': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-proposal-logical-assignment-operators': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-proposal-numeric-separator': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-proposal-optional-catch-binding': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-proposal-optional-chaining': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-proposal-private-methods': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-proposal-private-property-in-object': 7.20.5_@babel+core@7.21.0
+      '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.21.0
+      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.21.0
+      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.21.0
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.21.0
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.21.0
+      '@babel/plugin-syntax-import-assertions': 7.20.0_@babel+core@7.21.0
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.21.0
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.21.0
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.21.0
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.21.0
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.21.0
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.21.0
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.21.0
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.21.0
+      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.21.0
+      '@babel/plugin-transform-arrow-functions': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-transform-async-to-generator': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-transform-block-scoped-functions': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-transform-block-scoping': 7.20.14_@babel+core@7.21.0
+      '@babel/plugin-transform-classes': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-transform-computed-properties': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-transform-destructuring': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-transform-duplicate-keys': 7.18.9_@babel+core@7.21.0
+      '@babel/plugin-transform-exponentiation-operator': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-transform-for-of': 7.18.8_@babel+core@7.21.0
+      '@babel/plugin-transform-function-name': 7.18.9_@babel+core@7.21.0
+      '@babel/plugin-transform-literals': 7.18.9_@babel+core@7.21.0
+      '@babel/plugin-transform-member-expression-literals': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-transform-modules-amd': 7.20.11_@babel+core@7.21.0
+      '@babel/plugin-transform-modules-commonjs': 7.20.11_@babel+core@7.21.0
+      '@babel/plugin-transform-modules-systemjs': 7.20.11_@babel+core@7.21.0
+      '@babel/plugin-transform-modules-umd': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.20.5_@babel+core@7.21.0
+      '@babel/plugin-transform-new-target': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-transform-object-super': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-transform-parameters': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-transform-property-literals': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-transform-regenerator': 7.20.5_@babel+core@7.21.0
+      '@babel/plugin-transform-reserved-words': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-transform-shorthand-properties': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-transform-spread': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-transform-sticky-regex': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.21.0
+      '@babel/plugin-transform-typeof-symbol': 7.18.9_@babel+core@7.21.0
+      '@babel/plugin-transform-unicode-escapes': 7.18.10_@babel+core@7.21.0
+      '@babel/plugin-transform-unicode-regex': 7.18.6_@babel+core@7.21.0
+      '@babel/preset-modules': 0.1.5_@babel+core@7.21.0
       '@babel/types': 7.20.7
-      babel-plugin-polyfill-corejs2: 0.3.3_@babel+core@7.20.12
-      babel-plugin-polyfill-corejs3: 0.6.0_@babel+core@7.20.12
-      babel-plugin-polyfill-regenerator: 0.4.1_@babel+core@7.20.12
+      babel-plugin-polyfill-corejs2: 0.3.3_@babel+core@7.21.0
+      babel-plugin-polyfill-corejs3: 0.6.0_@babel+core@7.21.0
+      babel-plugin-polyfill-regenerator: 0.4.1_@babel+core@7.21.0
+      core-js-compat: 3.27.2
+      semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/preset-env/7.20.2_@babel+core@7.21.0:
+    resolution: {integrity: sha512-1G0efQEWR1EHkKvKHqbG+IN/QdgwfByUpM5V5QroDzGV2t3S/WXNQd693cHiHTlCFMpr9B6FkPFXDA2lQcKoDg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/compat-data': 7.20.14
+      '@babel/core': 7.21.0
+      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.21.0
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-validator-option': 7.18.6
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-proposal-async-generator-functions': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-proposal-class-static-block': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-proposal-dynamic-import': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-proposal-export-namespace-from': 7.18.9_@babel+core@7.21.0
+      '@babel/plugin-proposal-json-strings': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-proposal-logical-assignment-operators': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-proposal-numeric-separator': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-proposal-optional-catch-binding': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-proposal-optional-chaining': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-proposal-private-methods': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-proposal-private-property-in-object': 7.20.5_@babel+core@7.21.0
+      '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.21.0
+      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.21.0
+      '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.21.0
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.21.0
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.21.0
+      '@babel/plugin-syntax-import-assertions': 7.20.0_@babel+core@7.21.0
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.21.0
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.21.0
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.21.0
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.21.0
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.21.0
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.21.0
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.21.0
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.21.0
+      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.21.0
+      '@babel/plugin-transform-arrow-functions': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-transform-async-to-generator': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-transform-block-scoped-functions': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-transform-block-scoping': 7.20.14_@babel+core@7.21.0
+      '@babel/plugin-transform-classes': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-transform-computed-properties': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-transform-destructuring': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-transform-duplicate-keys': 7.18.9_@babel+core@7.21.0
+      '@babel/plugin-transform-exponentiation-operator': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-transform-for-of': 7.18.8_@babel+core@7.21.0
+      '@babel/plugin-transform-function-name': 7.18.9_@babel+core@7.21.0
+      '@babel/plugin-transform-literals': 7.18.9_@babel+core@7.21.0
+      '@babel/plugin-transform-member-expression-literals': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-transform-modules-amd': 7.20.11_@babel+core@7.21.0
+      '@babel/plugin-transform-modules-commonjs': 7.20.11_@babel+core@7.21.0
+      '@babel/plugin-transform-modules-systemjs': 7.20.11_@babel+core@7.21.0
+      '@babel/plugin-transform-modules-umd': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.20.5_@babel+core@7.21.0
+      '@babel/plugin-transform-new-target': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-transform-object-super': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-transform-parameters': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-transform-property-literals': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-transform-regenerator': 7.20.5_@babel+core@7.21.0
+      '@babel/plugin-transform-reserved-words': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-transform-shorthand-properties': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-transform-spread': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-transform-sticky-regex': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.21.0
+      '@babel/plugin-transform-typeof-symbol': 7.18.9_@babel+core@7.21.0
+      '@babel/plugin-transform-unicode-escapes': 7.18.10_@babel+core@7.21.0
+      '@babel/plugin-transform-unicode-regex': 7.18.6_@babel+core@7.21.0
+      '@babel/preset-modules': 0.1.5_@babel+core@7.21.0
+      '@babel/types': 7.20.7
+      babel-plugin-polyfill-corejs2: 0.3.3_@babel+core@7.21.0
+      babel-plugin-polyfill-corejs3: 0.6.0_@babel+core@7.21.0
+      babel-plugin-polyfill-regenerator: 0.4.1_@babel+core@7.21.0
       core-js-compat: 3.27.2
       semver: 6.3.0
     transitivePeerDependencies:
@@ -2593,15 +3057,27 @@ packages:
       '@babel/plugin-transform-flow-strip-types': 7.19.0_@babel+core@7.20.12
     dev: true
 
-  /@babel/preset-modules/0.1.5_@babel+core@7.20.12:
+  /@babel/preset-flow/7.18.6_@babel+core@7.21.0:
+    resolution: {integrity: sha512-E7BDhL64W6OUqpuyHnSroLnqyRTcG6ZdOBl1OKI/QK/HJfplqK/S3sq1Cckx7oTodJ5yOXyfw7rEADJ6UjoQDQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-validator-option': 7.18.6
+      '@babel/plugin-transform-flow-strip-types': 7.19.0_@babel+core@7.21.0
+    dev: true
+
+  /@babel/preset-modules/0.1.5_@babel+core@7.21.0:
     resolution: {integrity: sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.20.12
+      '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.21.0
       '@babel/types': 7.20.7
       esutils: 2.0.3
     dev: true
@@ -2619,6 +3095,21 @@ packages:
       '@babel/plugin-transform-react-jsx': 7.20.13_@babel+core@7.20.12
       '@babel/plugin-transform-react-jsx-development': 7.18.6_@babel+core@7.20.12
       '@babel/plugin-transform-react-pure-annotations': 7.18.6_@babel+core@7.20.12
+    dev: true
+
+  /@babel/preset-react/7.18.6_@babel+core@7.21.0:
+    resolution: {integrity: sha512-zXr6atUmyYdiWRVLOZahakYmOBHtWc2WGCkP8PYTgZi0iJXDY2CN180TdrIW4OGOAdLc7TifzDIvtx6izaRIzg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-validator-option': 7.18.6
+      '@babel/plugin-transform-react-display-name': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-transform-react-jsx': 7.20.13_@babel+core@7.21.0
+      '@babel/plugin-transform-react-jsx-development': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-transform-react-pure-annotations': 7.18.6_@babel+core@7.21.0
     dev: true
 
   /@babel/preset-typescript/7.18.6_@babel+core@7.20.12:
@@ -3099,26 +3590,6 @@ packages:
     resolution: {integrity: sha512-8HqW8EVqjnCmWXVpqAOZf+EGESdkR27odcMMMGefgKXtar00SoYNSryGv//TELI4T3QFsECo78p+0lmalk/CFA==}
     dev: false
 
-  /@emotion/babel-plugin/11.10.5_@babel+core@7.20.12:
-    resolution: {integrity: sha512-xE7/hyLHJac7D2Ve9dKroBBZqBT7WuPQmWcq7HSGb84sUuP4mlOWoB8dvVfD9yk5DHkU1m6RW7xSoDtnQHNQeA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.20.12
-      '@babel/runtime': 7.20.13
-      '@emotion/hash': 0.9.0
-      '@emotion/memoize': 0.8.0
-      '@emotion/serialize': 1.1.1
-      babel-plugin-macros: 3.1.0
-      convert-source-map: 1.9.0
-      escape-string-regexp: 4.0.0
-      find-root: 1.1.0
-      source-map: 0.5.7
-      stylis: 4.1.3
-    dev: false
-
   /@emotion/babel-plugin/11.10.5_@babel+core@7.21.0:
     resolution: {integrity: sha512-xE7/hyLHJac7D2Ve9dKroBBZqBT7WuPQmWcq7HSGb84sUuP4mlOWoB8dvVfD9yk5DHkU1m6RW7xSoDtnQHNQeA==}
     peerDependencies:
@@ -3175,30 +3646,6 @@ packages:
     resolution: {integrity: sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==}
     dev: false
 
-  /@emotion/react/11.10.5_2exiyaescjxorpwwmy4ejghgte:
-    resolution: {integrity: sha512-TZs6235tCJ/7iF6/rvTaOH4oxQg2gMAcdHemjwLKIjKz4rRuYe1HJ2TQJKnAcRAfOUDdU8XoDadCe1rl72iv8A==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      '@types/react': '*'
-      react: '>=16.8.0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@types/react':
-        optional: true
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/runtime': 7.20.13
-      '@emotion/babel-plugin': 11.10.5_@babel+core@7.20.12
-      '@emotion/cache': 11.10.5
-      '@emotion/serialize': 1.1.1
-      '@emotion/use-insertion-effect-with-fallbacks': 1.0.0_react@18.2.0
-      '@emotion/utils': 1.2.0
-      '@emotion/weak-memoize': 0.3.0
-      hoist-non-react-statics: 3.3.2
-      react: 18.2.0
-    dev: false
-
   /@emotion/react/11.10.5_gqz5z5osutjfnjhhqhx3ybpdoy:
     resolution: {integrity: sha512-TZs6235tCJ/7iF6/rvTaOH4oxQg2gMAcdHemjwLKIjKz4rRuYe1HJ2TQJKnAcRAfOUDdU8XoDadCe1rl72iv8A==}
     peerDependencies:
@@ -3224,7 +3671,7 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@emotion/react/11.10.5_yxdp3dl3eazy3vwpbmv4fq727a:
+  /@emotion/react/11.10.5_l7cfjcftkbbrwrylsnya5ld57q:
     resolution: {integrity: sha512-TZs6235tCJ/7iF6/rvTaOH4oxQg2gMAcdHemjwLKIjKz4rRuYe1HJ2TQJKnAcRAfOUDdU8XoDadCe1rl72iv8A==}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -3236,15 +3683,39 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/runtime': 7.20.13
-      '@emotion/babel-plugin': 11.10.5_@babel+core@7.20.12
+      '@emotion/babel-plugin': 11.10.5_@babel+core@7.21.0
       '@emotion/cache': 11.10.5
       '@emotion/serialize': 1.1.1
       '@emotion/use-insertion-effect-with-fallbacks': 1.0.0_react@18.2.0
       '@emotion/utils': 1.2.0
       '@emotion/weak-memoize': 0.3.0
       '@types/react': 18.0.27
+      hoist-non-react-statics: 3.3.2
+      react: 18.2.0
+    dev: false
+
+  /@emotion/react/11.10.5_q2tyk3gci27qk4qoatek53e4vi:
+    resolution: {integrity: sha512-TZs6235tCJ/7iF6/rvTaOH4oxQg2gMAcdHemjwLKIjKz4rRuYe1HJ2TQJKnAcRAfOUDdU8XoDadCe1rl72iv8A==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+      '@types/react': '*'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/runtime': 7.20.13
+      '@emotion/babel-plugin': 11.10.5_@babel+core@7.21.0
+      '@emotion/cache': 11.10.5
+      '@emotion/serialize': 1.1.1
+      '@emotion/use-insertion-effect-with-fallbacks': 1.0.0_react@18.2.0
+      '@emotion/utils': 1.2.0
+      '@emotion/weak-memoize': 0.3.0
       hoist-non-react-statics: 3.3.2
       react: 18.2.0
     dev: false
@@ -4858,7 +5329,7 @@ packages:
       '@babel/parser': 7.20.13
       '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.20.12
       '@babel/plugin-syntax-typescript': 7.20.0_@babel+core@7.20.12
-      '@babel/preset-env': 7.20.2_@babel+core@7.20.12
+      '@babel/preset-env': 7.20.2_@babel+core@7.21.0
       '@babel/preset-typescript': 7.18.6_@babel+core@7.20.12
       '@babel/traverse': 7.20.13
       '@babel/types': 7.20.7
@@ -5876,7 +6347,7 @@ packages:
       - supports-color
     dev: false
 
-  /@sanity/vision/3.2.4_6s5bknaubhoec4q4gecpxwo76e:
+  /@sanity/vision/3.2.4_ywmsopb22zxkrxg36znnfelhzq:
     resolution: {integrity: sha512-nzz9JC5ob600ryfVGKCioDiqlUdZWhLw2GESkCDscstGbcpN7toA2XdiEY2rObkmCJPrmP0MfbQUcpL3CO66MA==}
     peerDependencies:
       react: ^18
@@ -5895,7 +6366,7 @@ packages:
       '@sanity/color': 2.2.2
       '@sanity/icons': 2.2.2_react@18.2.0
       '@sanity/ui': 1.0.14_23mhwjhnzfjwvdn7ol54k26zom
-      '@uiw/react-codemirror': 4.19.7_6mdwrs5z4r6dg4a46fl6hjkjlu
+      '@uiw/react-codemirror': 4.19.7_hyqoqjuqac6lr42lwbvn3tayra
       hashlru: 2.3.0
       is-hotkey: 0.1.8
       json5: 2.2.3
@@ -5913,7 +6384,7 @@ packages:
       - react-is
     dev: false
 
-  /@sanity/vision/3.4.0_6s5bknaubhoec4q4gecpxwo76e:
+  /@sanity/vision/3.4.0_ywmsopb22zxkrxg36znnfelhzq:
     resolution: {integrity: sha512-3oWTJ61S5sXuyrftoG8nbRqdiJgQZE0ILy74YxMTjx0YYneElUFi1Hae277/gmLweaJZbhIZIjOyOD60tZh0Pw==}
     peerDependencies:
       react: ^18
@@ -5932,7 +6403,7 @@ packages:
       '@sanity/color': 2.2.3
       '@sanity/icons': 2.2.2_react@18.2.0
       '@sanity/ui': 1.2.4_23mhwjhnzfjwvdn7ol54k26zom
-      '@uiw/react-codemirror': 4.19.9_e6pxnuyx6vt54iwyssqtj74rye
+      '@uiw/react-codemirror': 4.19.9_3xqscpa56wh2bvbchyuroirwv4
       hashlru: 2.3.0
       is-hotkey: 0.1.8
       json5: 2.2.3
@@ -6109,7 +6580,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/addon-docs/6.5.16_uo3efmxzlo6oik6iaxblvhk4he:
+  /@storybook/addon-docs/6.5.16_snd4n6aikgwaba6tlo47rkkfhi:
     resolution: {integrity: sha512-QM9WDZG9P02UvbzLu947a8ZngOrQeAKAT8jCibQFM/+RJ39xBlfm8rm+cQy3dm94wgtjmVkA3mKGOV/yrrsddg==}
     peerDependencies:
       '@storybook/mdx2-csf': ^0.0.3
@@ -6123,8 +6594,8 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@babel/plugin-transform-react-jsx': 7.20.13_@babel+core@7.20.12
-      '@babel/preset-env': 7.20.2_@babel+core@7.20.12
+      '@babel/plugin-transform-react-jsx': 7.20.13_@babel+core@7.21.0
+      '@babel/preset-env': 7.20.2_@babel+core@7.21.0
       '@jest/transform': 26.6.2
       '@mdx-js/react': 1.6.22_react@18.2.0
       '@storybook/addons': 6.5.16_biqbaboplfbrettd7655fr4n2y
@@ -6134,14 +6605,14 @@ packages:
       '@storybook/core-events': 6.5.16
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/mdx1-csf': 0.0.1_@babel+core@7.20.12
+      '@storybook/mdx1-csf': 0.0.1_@babel+core@7.21.0
       '@storybook/node-logger': 6.5.16
       '@storybook/postinstall': 6.5.16
       '@storybook/preview-web': 6.5.16_biqbaboplfbrettd7655fr4n2y
       '@storybook/source-loader': 6.5.16_biqbaboplfbrettd7655fr4n2y
       '@storybook/store': 6.5.16_biqbaboplfbrettd7655fr4n2y
       '@storybook/theming': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      babel-loader: 8.3.0_la66t7xldg4uecmyawueag5wkm
+      babel-loader: 8.3.0_qoaxtqicpzj5p3ubthw53xafqm
       core-js: 3.27.2
       fast-deep-equal: 3.1.3
       global: 4.4.0
@@ -6164,7 +6635,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/addon-essentials/6.5.16_qfg2oyphijmbfyorruyfikzjbu:
+  /@storybook/addon-essentials/6.5.16_grb24zorjb6ghupi76c2w3qx4u:
     resolution: {integrity: sha512-TeoMr6tEit4Pe91GH6f8g/oar1P4M0JL9S6oMcFxxrhhtOGO7XkWD5EnfyCx272Ok2VYfE58FNBTGPNBVIqYKQ==}
     peerDependencies:
       '@babel/core': ^7.9.6
@@ -6221,11 +6692,11 @@ packages:
       webpack:
         optional: true
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@storybook/addon-actions': 6.5.16_biqbaboplfbrettd7655fr4n2y
       '@storybook/addon-backgrounds': 6.5.16_biqbaboplfbrettd7655fr4n2y
       '@storybook/addon-controls': 6.5.16_o4scbtliisanygemawej7x2d6i
-      '@storybook/addon-docs': 6.5.16_uo3efmxzlo6oik6iaxblvhk4he
+      '@storybook/addon-docs': 6.5.16_snd4n6aikgwaba6tlo47rkkfhi
       '@storybook/addon-measure': 6.5.16_biqbaboplfbrettd7655fr4n2y
       '@storybook/addon-outline': 6.5.16_biqbaboplfbrettd7655fr4n2y
       '@storybook/addon-toolbars': 6.5.16_biqbaboplfbrettd7655fr4n2y
@@ -7101,6 +7572,25 @@ packages:
       - supports-color
     dev: true
 
+  /@storybook/mdx1-csf/0.0.1_@babel+core@7.21.0:
+    resolution: {integrity: sha512-4biZIWWzoWlCarMZmTpqcJNgo/RBesYZwGFbQeXiGYsswuvfWARZnW9RE9aUEMZ4XPn7B1N3EKkWcdcWe/K2tg==}
+    dependencies:
+      '@babel/generator': 7.20.14
+      '@babel/parser': 7.20.13
+      '@babel/preset-env': 7.20.2_@babel+core@7.21.0
+      '@babel/types': 7.20.7
+      '@mdx-js/mdx': 1.6.22
+      '@types/lodash': 4.14.191
+      js-string-escape: 1.0.1
+      loader-utils: 2.0.4
+      lodash: 4.17.21
+      prettier: 2.3.0
+      ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+    dev: true
+
   /@storybook/node-logger/6.5.16:
     resolution: {integrity: sha512-YjhBKrclQtjhqFNSO+BZK+RXOx6EQypAELJKoLFaawg331e8VUfvUuRCNB3fcEWp8G9oH13PQQte0OTjLyyOYg==}
     dependencies:
@@ -7172,7 +7662,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/react/6.5.16_dpfgtf3aew22p6fuhy7t4xrcb4:
+  /@storybook/react/6.5.16_4nfcraixckxvlsvnxdksc45hzi:
     resolution: {integrity: sha512-cBtNlOzf/MySpNLBK22lJ8wFU22HnfTB2xJyBk7W7Zi71Lm7Uxkhv1Pz8HdiQndJ0SlsAAQOWjQYsSZsGkZIaA==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -7200,9 +7690,9 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@babel/core': 7.20.12
-      '@babel/preset-flow': 7.18.6_@babel+core@7.20.12
-      '@babel/preset-react': 7.18.6_@babel+core@7.20.12
+      '@babel/core': 7.21.0
+      '@babel/preset-flow': 7.18.6_@babel+core@7.21.0
+      '@babel/preset-react': 7.18.6_@babel+core@7.21.0
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.10_ohj47mxwagpoxvu7nhhwxzphqm
       '@storybook/addons': 6.5.16_biqbaboplfbrettd7655fr4n2y
       '@storybook/builder-webpack5': 6.5.16_o4scbtliisanygemawej7x2d6i
@@ -7750,7 +8240,7 @@ packages:
     resolution: {integrity: sha512-RMSSvSfs9kb0VzkvQ2NWobwnj7TxCA9vI/IjR9bDHqgAyVbu2T0DN4wiKVqomyDWqO7dPr/tErSfq7urQ1Q37g==}
     dependencies:
       fast-glob: 3.2.12
-      minimatch: 5.1.2
+      minimatch: 5.1.6
       mkdirp: 1.0.4
       path-browserify: 1.0.1
     dev: true
@@ -8389,7 +8879,7 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.46.1_2facupdxlvm55gtp63dnpqcawi:
+  /@typescript-eslint/eslint-plugin/5.46.1_jfexnejfvdoaivzgwqqlsbumnu:
     resolution: {integrity: sha512-YpzNv3aayRBwjs4J3oz65eVLXc9xx0PDbIRisHj+dYhvBn02MjYOD96P8YGiWEIFBrojaUjxvkaUpakD82phsA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8400,12 +8890,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.52.0_ehfyfk7qbmgzg5nk6xmobqdh3a
+      '@typescript-eslint/parser': 5.54.0_ddvlikdjy3uujmudifwl7fbpl4
       '@typescript-eslint/scope-manager': 5.46.1
-      '@typescript-eslint/type-utils': 5.46.1_ehfyfk7qbmgzg5nk6xmobqdh3a
-      '@typescript-eslint/utils': 5.46.1_ehfyfk7qbmgzg5nk6xmobqdh3a
+      '@typescript-eslint/type-utils': 5.46.1_ddvlikdjy3uujmudifwl7fbpl4
+      '@typescript-eslint/utils': 5.46.1_ddvlikdjy3uujmudifwl7fbpl4
       debug: 4.3.4
-      eslint: 8.34.0
+      eslint: 8.35.0
       ignore: 5.2.1
       natural-compare-lite: 1.4.0
       regexpp: 3.2.0
@@ -8471,7 +8961,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.47.0_ehfyfk7qbmgzg5nk6xmobqdh3a:
+  /@typescript-eslint/parser/5.47.0_ddvlikdjy3uujmudifwl7fbpl4:
     resolution: {integrity: sha512-udPU4ckK+R1JWCGdQC4Qa27NtBg7w020ffHqGyAK8pAgOVuNw7YaKXGChk+udh+iiGIJf6/E/0xhVXyPAbsczw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8485,7 +8975,7 @@ packages:
       '@typescript-eslint/types': 5.47.0
       '@typescript-eslint/typescript-estree': 5.47.0_typescript@4.9.4
       debug: 4.3.4
-      eslint: 8.34.0
+      eslint: 8.35.0
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
@@ -8531,8 +9021,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.52.0_ehfyfk7qbmgzg5nk6xmobqdh3a:
-    resolution: {integrity: sha512-e2KiLQOZRo4Y0D/b+3y08i3jsekoSkOYStROYmPUnGMEoA0h+k2qOH5H6tcjIc68WDvGwH+PaOrP1XRzLJ6QlA==}
+  /@typescript-eslint/parser/5.54.0_ddvlikdjy3uujmudifwl7fbpl4:
+    resolution: {integrity: sha512-aAVL3Mu2qTi+h/r04WI/5PfNWvO6pdhpeMRWk9R7rEV4mwJNzoWf5CCU5vDKBsPIFQFjEq1xg7XBI2rjiMXQbQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -8541,11 +9031,11 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 5.52.0
-      '@typescript-eslint/types': 5.52.0
-      '@typescript-eslint/typescript-estree': 5.52.0_typescript@4.9.4
+      '@typescript-eslint/scope-manager': 5.54.0
+      '@typescript-eslint/types': 5.54.0
+      '@typescript-eslint/typescript-estree': 5.54.0_typescript@4.9.4
       debug: 4.3.4
-      eslint: 8.34.0
+      eslint: 8.35.0
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
@@ -8616,7 +9106,7 @@ packages:
       '@typescript-eslint/types': 5.54.0
       '@typescript-eslint/visitor-keys': 5.54.0
 
-  /@typescript-eslint/type-utils/5.46.1_ehfyfk7qbmgzg5nk6xmobqdh3a:
+  /@typescript-eslint/type-utils/5.46.1_ddvlikdjy3uujmudifwl7fbpl4:
     resolution: {integrity: sha512-V/zMyfI+jDmL1ADxfDxjZ0EMbtiVqj8LUGPAGyBkXXStWmCUErMpW873zEHsyguWCuq2iN4BrlWUkmuVj84yng==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8627,9 +9117,9 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/typescript-estree': 5.46.1_typescript@4.9.4
-      '@typescript-eslint/utils': 5.46.1_ehfyfk7qbmgzg5nk6xmobqdh3a
+      '@typescript-eslint/utils': 5.46.1_ddvlikdjy3uujmudifwl7fbpl4
       debug: 4.3.4
-      eslint: 8.34.0
+      eslint: 8.35.0
       tsutils: 3.21.0_typescript@4.9.4
       typescript: 4.9.4
     transitivePeerDependencies:
@@ -8788,27 +9278,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.52.0_typescript@4.9.4:
-    resolution: {integrity: sha512-WeWnjanyEwt6+fVrSR0MYgEpUAuROxuAH516WPjUblIrClzYJj0kBbjdnbQXLpgAN8qbEuGywiQsXUVDiAoEuQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.52.0
-      '@typescript-eslint/visitor-keys': 5.52.0
-      debug: 4.3.4
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.9.4
-      typescript: 4.9.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/typescript-estree/5.52.0_typescript@4.9.5:
     resolution: {integrity: sha512-WeWnjanyEwt6+fVrSR0MYgEpUAuROxuAH516WPjUblIrClzYJj0kBbjdnbQXLpgAN8qbEuGywiQsXUVDiAoEuQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -8826,6 +9295,27 @@ packages:
       semver: 7.3.8
       tsutils: 3.21.0_typescript@4.9.5
       typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/typescript-estree/5.54.0_typescript@4.9.4:
+    resolution: {integrity: sha512-X2rJG97Wj/VRo5YxJ8Qx26Zqf0RRKsVHd4sav8NElhbZzhpBI8jU54i6hfo9eheumj4oO4dcRN1B/zIVEqR/MQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.54.0
+      '@typescript-eslint/visitor-keys': 5.54.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.3.8
+      tsutils: 3.21.0_typescript@4.9.4
+      typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8850,7 +9340,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/utils/5.46.1_ehfyfk7qbmgzg5nk6xmobqdh3a:
+  /@typescript-eslint/utils/5.46.1_ddvlikdjy3uujmudifwl7fbpl4:
     resolution: {integrity: sha512-RBdBAGv3oEpFojaCYT4Ghn4775pdjvwfDOfQ2P6qzNVgQOVrnSPe5/Pb88kv7xzYQjoio0eKHKB9GJ16ieSxvA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8861,9 +9351,9 @@ packages:
       '@typescript-eslint/scope-manager': 5.46.1
       '@typescript-eslint/types': 5.46.1
       '@typescript-eslint/typescript-estree': 5.46.1_typescript@4.9.4
-      eslint: 8.34.0
+      eslint: 8.35.0
       eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@8.34.0
+      eslint-utils: 3.0.0_eslint@8.35.0
       semver: 7.3.8
     transitivePeerDependencies:
       - supports-color
@@ -8956,7 +9446,7 @@ packages:
       '@typescript-eslint/types': 5.54.0
       eslint-visitor-keys: 3.3.0
 
-  /@uiw/codemirror-extensions-basic-setup/4.19.7_xcbtxymuwicixsrdklqkmd5eui:
+  /@uiw/codemirror-extensions-basic-setup/4.19.7_3tyi5r6do5gp2wsjg2a5en2ssm:
     resolution: {integrity: sha512-pk0JTFJAZOGxouBB1pdBtb59qKibO9DW4hER4VSFGBGW3TBDeXUwL/gKujhRpySHG2MtG09cgt4a3XOFIWwXTw==}
     peerDependencies:
       '@codemirror/autocomplete': '>=6.0.0'
@@ -8970,7 +9460,7 @@ packages:
       '@codemirror/autocomplete': 6.4.0_4brt7ssv37vk5p4hmzax5oqmt4
       '@codemirror/commands': 6.2.0
       '@codemirror/language': 6.4.0
-      '@codemirror/lint': 6.1.1
+      '@codemirror/lint': 6.2.0
       '@codemirror/search': 6.2.3
       '@codemirror/state': 6.2.0
       '@codemirror/view': 6.7.3
@@ -8996,27 +9486,7 @@ packages:
       '@codemirror/view': 6.9.1
     dev: false
 
-  /@uiw/codemirror-extensions-basic-setup/4.19.9_qke3p6mgbtditdp7e37bsdxoae:
-    resolution: {integrity: sha512-O4yAgVpD3Pon4t4+lwZ2MTGg2TeU/Jv8YzKS9ap4fP/WMTVrKmpdq+DOafbhZSlhmU0XGfQPPJ4WX6rtZgx3Rw==}
-    peerDependencies:
-      '@codemirror/autocomplete': '>=6.0.0'
-      '@codemirror/commands': '>=6.0.0'
-      '@codemirror/language': '>=6.0.0'
-      '@codemirror/lint': '>=6.0.0'
-      '@codemirror/search': '>=6.0.0'
-      '@codemirror/state': '>=6.0.0'
-      '@codemirror/view': '>=6.0.0'
-    dependencies:
-      '@codemirror/autocomplete': 6.4.2_4brt7ssv37vk5p4hmzax5oqmt4
-      '@codemirror/commands': 6.2.1
-      '@codemirror/language': 6.6.0
-      '@codemirror/lint': 6.1.1
-      '@codemirror/search': 6.2.3
-      '@codemirror/state': 6.2.0
-      '@codemirror/view': 6.9.1
-    dev: false
-
-  /@uiw/react-codemirror/4.19.7_6mdwrs5z4r6dg4a46fl6hjkjlu:
+  /@uiw/react-codemirror/4.19.7_hyqoqjuqac6lr42lwbvn3tayra:
     resolution: {integrity: sha512-IHvpYWVSdiaHX0Fk6oY6YyAJigDnyvSpWKNUTRzsMNxB+8/wqZ8lior4TprXH0zyLxW5F1+bTyifFFTeg+X3Sw==}
     peerDependencies:
       '@babel/runtime': '>=7.11.0'
@@ -9027,12 +9497,12 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@codemirror/commands': 6.2.0
       '@codemirror/state': 6.2.0
       '@codemirror/theme-one-dark': 6.1.1
       '@codemirror/view': 6.7.3
-      '@uiw/codemirror-extensions-basic-setup': 4.19.7_xcbtxymuwicixsrdklqkmd5eui
+      '@uiw/codemirror-extensions-basic-setup': 4.19.7_3tyi5r6do5gp2wsjg2a5en2ssm
       codemirror: 6.0.1_@lezer+common@1.0.2
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -9060,33 +9530,6 @@ packages:
       '@codemirror/theme-one-dark': 6.1.1
       '@codemirror/view': 6.9.1
       '@uiw/codemirror-extensions-basic-setup': 4.19.9_hp7qg7fwdmjshmrtsn74dvuq6a
-      codemirror: 6.0.1_@lezer+common@1.0.2
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-    transitivePeerDependencies:
-      - '@codemirror/autocomplete'
-      - '@codemirror/language'
-      - '@codemirror/lint'
-      - '@codemirror/search'
-    dev: false
-
-  /@uiw/react-codemirror/4.19.9_e6pxnuyx6vt54iwyssqtj74rye:
-    resolution: {integrity: sha512-U+A1fSfELMFFs5a+ZOPwCJKZMYaMy6QHOfNOOV7WhSveM7GYHT970GjTfs2dn1LlvhebwyK9ei0rCXZdsI9n9Q==}
-    peerDependencies:
-      '@babel/runtime': '>=7.11.0'
-      '@codemirror/state': '>=6.0.0'
-      '@codemirror/theme-one-dark': '>=6.0.0'
-      '@codemirror/view': '>=6.0.0'
-      codemirror: '>=6.0.0'
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-    dependencies:
-      '@babel/runtime': 7.20.13
-      '@codemirror/commands': 6.2.1
-      '@codemirror/state': 6.2.0
-      '@codemirror/theme-one-dark': 6.1.1
-      '@codemirror/view': 6.9.1
-      '@uiw/codemirror-extensions-basic-setup': 4.19.9_qke3p6mgbtditdp7e37bsdxoae
       codemirror: 6.0.1_@lezer+common@1.0.2
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -9627,31 +10070,16 @@ packages:
       - supports-color
     dev: true
 
-  /@xstate/cli/0.4.2_prettier@2.8.1:
-    resolution: {integrity: sha512-lxj7YrpCl3azlzHO98oBp+qklKUvkw3AjWG815pVyNNf5Wm7JunYtPkGiqif6wCg1K/7V0x8cMdLzxhFkKBk9w==}
-    hasBin: true
-    dependencies:
-      '@babel/core': 7.21.0
-      '@xstate/machine-extractor': 0.9.0_xstate@4.37.0
-      '@xstate/tools-shared': 2.0.2_zrhzzrj2kqlcfr3recrjhrbbuu
-      chokidar: 3.5.3
-      commander: 8.3.0
-      xstate: 4.37.0
-    transitivePeerDependencies:
-      - prettier
-      - supports-color
-    dev: true
-
   /@xstate/cli/0.4.2_prettier@2.8.3:
     resolution: {integrity: sha512-lxj7YrpCl3azlzHO98oBp+qklKUvkw3AjWG815pVyNNf5Wm7JunYtPkGiqif6wCg1K/7V0x8cMdLzxhFkKBk9w==}
     hasBin: true
     dependencies:
       '@babel/core': 7.20.12
-      '@xstate/machine-extractor': 0.9.0_xstate@4.35.4
-      '@xstate/tools-shared': 2.0.2_dbovkgjst7vle3mo2dvb2riqd4
+      '@xstate/machine-extractor': 0.9.0_xstate@4.36.0
+      '@xstate/tools-shared': 2.0.2_hkg7b2bt4ed7u4n2cdb5dr7isy
       chokidar: 3.5.3
       commander: 8.3.0
-      xstate: 4.35.4
+      xstate: 4.36.0
     transitivePeerDependencies:
       - prettier
       - supports-color
@@ -9661,12 +10089,12 @@ packages:
     resolution: {integrity: sha512-lxj7YrpCl3azlzHO98oBp+qklKUvkw3AjWG815pVyNNf5Wm7JunYtPkGiqif6wCg1K/7V0x8cMdLzxhFkKBk9w==}
     hasBin: true
     dependencies:
-      '@babel/core': 7.20.12
-      '@xstate/machine-extractor': 0.9.0_xstate@4.36.0
-      '@xstate/tools-shared': 2.0.2_53mj2qqxkwptlqnqogtjteizni
+      '@babel/core': 7.21.0
+      '@xstate/machine-extractor': 0.9.0_xstate@4.37.0
+      '@xstate/tools-shared': 2.0.2_fpbd6wlrgx2bnll4ovuddub7um
       chokidar: 3.5.3
       commander: 8.3.0
-      xstate: 4.36.0
+      xstate: 4.37.0
     transitivePeerDependencies:
       - prettier
       - supports-color
@@ -9676,25 +10104,11 @@ packages:
     peerDependencies:
       xstate: ^4
     dependencies:
-      '@babel/parser': 7.20.5
-      '@babel/traverse': 7.20.5
-      '@babel/types': 7.20.5
-      recast: 0.21.5
-      xstate: 4.35.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@xstate/machine-extractor/0.9.0_xstate@4.35.4:
-    resolution: {integrity: sha512-QtjlBHdIp6OwwsSpbAwa4U2/WzijnW+EMu2Tgj20t94zMlQFtbOE2l5dnI4u/DWJBK+/S9zj39qIAmdlQFx8/w==}
-    peerDependencies:
-      xstate: ^4
-    dependencies:
       '@babel/parser': 7.20.13
       '@babel/traverse': 7.20.13
       '@babel/types': 7.20.7
       recast: 0.21.5
-      xstate: 4.35.4
+      xstate: 4.35.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9711,6 +10125,7 @@ packages:
       xstate: 4.36.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@xstate/machine-extractor/0.9.0_xstate@4.37.0:
     resolution: {integrity: sha512-QtjlBHdIp6OwwsSpbAwa4U2/WzijnW+EMu2Tgj20t94zMlQFtbOE2l5dnI4u/DWJBK+/S9zj39qIAmdlQFx8/w==}
@@ -9724,7 +10139,6 @@ packages:
       xstate: 4.37.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@xstate/react/3.0.1_jxlbbcdnowciznag5x5yc5bb5i:
     resolution: {integrity: sha512-/tq/gg92P9ke8J+yDNDBv5/PAxBvXJf2cYyGDByzgtl5wKaxKxzDT82Gj3eWlCJXkrBg4J5/V47//gRJuVH2fA==}
@@ -9835,40 +10249,27 @@ packages:
       - supports-color
     dev: true
 
-  /@xstate/tools-shared/2.0.2_53mj2qqxkwptlqnqogtjteizni:
-    resolution: {integrity: sha512-Lg8RD19Jq62M8KsnSF8Tenqo0a8/j7eqzHCpxG7ewc9PklkOcLvOWN4rrGTtYG5zkxJNQTXq8kt2x0TsWwnumQ==}
-    peerDependencies:
-      prettier: ^2.3.1
-      xstate: ^4
-    dependencies:
-      '@xstate/machine-extractor': 0.9.0_xstate@4.36.0
-      prettier: 2.8.4
-      xstate: 4.36.0
-    transitivePeerDependencies:
-      - supports-color
-
-  /@xstate/tools-shared/2.0.2_dbovkgjst7vle3mo2dvb2riqd4:
-    resolution: {integrity: sha512-Lg8RD19Jq62M8KsnSF8Tenqo0a8/j7eqzHCpxG7ewc9PklkOcLvOWN4rrGTtYG5zkxJNQTXq8kt2x0TsWwnumQ==}
-    peerDependencies:
-      prettier: ^2.3.1
-      xstate: ^4
-    dependencies:
-      '@xstate/machine-extractor': 0.9.0_xstate@4.35.4
-      prettier: 2.8.3
-      xstate: 4.35.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@xstate/tools-shared/2.0.2_zrhzzrj2kqlcfr3recrjhrbbuu:
+  /@xstate/tools-shared/2.0.2_fpbd6wlrgx2bnll4ovuddub7um:
     resolution: {integrity: sha512-Lg8RD19Jq62M8KsnSF8Tenqo0a8/j7eqzHCpxG7ewc9PklkOcLvOWN4rrGTtYG5zkxJNQTXq8kt2x0TsWwnumQ==}
     peerDependencies:
       prettier: ^2.3.1
       xstate: ^4
     dependencies:
       '@xstate/machine-extractor': 0.9.0_xstate@4.37.0
-      prettier: 2.8.1
+      prettier: 2.8.4
       xstate: 4.37.0
+    transitivePeerDependencies:
+      - supports-color
+
+  /@xstate/tools-shared/2.0.2_hkg7b2bt4ed7u4n2cdb5dr7isy:
+    resolution: {integrity: sha512-Lg8RD19Jq62M8KsnSF8Tenqo0a8/j7eqzHCpxG7ewc9PklkOcLvOWN4rrGTtYG5zkxJNQTXq8kt2x0TsWwnumQ==}
+    peerDependencies:
+      prettier: ^2.3.1
+      xstate: ^4
+    dependencies:
+      '@xstate/machine-extractor': 0.9.0_xstate@4.36.0
+      prettier: 2.8.3
+      xstate: 4.36.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10717,6 +11118,21 @@ packages:
       webpack: 4.46.0
     dev: true
 
+  /babel-loader/8.3.0_qoaxtqicpzj5p3ubthw53xafqm:
+    resolution: {integrity: sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==}
+    engines: {node: '>= 8.9'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+      webpack: '>=2'
+    dependencies:
+      '@babel/core': 7.21.0
+      find-cache-dir: 3.3.2
+      loader-utils: 2.0.4
+      make-dir: 3.1.0
+      schema-utils: 2.7.1
+      webpack: 5.75.0
+    dev: true
+
   /babel-plugin-add-react-displayname/0.0.5:
     resolution: {integrity: sha512-LY3+Y0XVDYcShHHorshrDbt4KFWL4bSeniCtl4SYZbask+Syngk1uMPCeN9+nSiZo6zX5s0RTq/J9Pnaaf/KHw==}
     dev: true
@@ -10772,14 +11188,14 @@ packages:
     resolution: {integrity: sha512-OgOYHOLoRK+/mvXU9imKHlG6GkPLYrUCvFXG/CM93R/aNNO8pOOF4aS+S8CCHMDQoNSeiOYEZb/G6RwL95Jktw==}
     dev: true
 
-  /babel-plugin-polyfill-corejs2/0.3.3_@babel+core@7.20.12:
+  /babel-plugin-polyfill-corejs2/0.3.3_@babel+core@7.21.0:
     resolution: {integrity: sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.20.14
-      '@babel/core': 7.20.12
-      '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.20.12
+      '@babel/core': 7.21.0
+      '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.21.0
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
@@ -10797,25 +11213,25 @@ packages:
       - supports-color
     dev: true
 
-  /babel-plugin-polyfill-corejs3/0.6.0_@babel+core@7.20.12:
+  /babel-plugin-polyfill-corejs3/0.6.0_@babel+core@7.21.0:
     resolution: {integrity: sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.20.12
+      '@babel/core': 7.21.0
+      '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.21.0
       core-js-compat: 3.27.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /babel-plugin-polyfill-regenerator/0.4.1_@babel+core@7.20.12:
+  /babel-plugin-polyfill-regenerator/0.4.1_@babel+core@7.21.0:
     resolution: {integrity: sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.20.12
+      '@babel/core': 7.21.0
+      '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.21.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -13820,7 +14236,7 @@ packages:
     optionalDependencies:
       source-map: 0.6.1
 
-  /eslint-config-next/13.0.7_ehfyfk7qbmgzg5nk6xmobqdh3a:
+  /eslint-config-next/13.0.7_ddvlikdjy3uujmudifwl7fbpl4:
     resolution: {integrity: sha512-X7DB7iDJ9iHi5DAZbnFdWm4M0dwarj5h5y6Vpm9INCYzFgAwSWslq3v0qjYEjtUO5IQ8n1WK6IU5FkOQ2HBhOA==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0
@@ -13831,14 +14247,14 @@ packages:
     dependencies:
       '@next/eslint-plugin-next': 13.0.7
       '@rushstack/eslint-patch': 1.2.0
-      '@typescript-eslint/parser': 5.47.0_ehfyfk7qbmgzg5nk6xmobqdh3a
-      eslint: 8.34.0
+      '@typescript-eslint/parser': 5.47.0_ddvlikdjy3uujmudifwl7fbpl4
+      eslint: 8.35.0
       eslint-import-resolver-node: 0.3.6
-      eslint-import-resolver-typescript: 3.5.2_w7dy265x2bmlgtc6kmsfumkjde
-      eslint-plugin-import: 2.26.0_mcvs2y73sfmcxqzpjj5lr7a2m4
-      eslint-plugin-jsx-a11y: 6.6.1_eslint@8.34.0
-      eslint-plugin-react: 7.31.11_eslint@8.34.0
-      eslint-plugin-react-hooks: 4.6.0_eslint@8.34.0
+      eslint-import-resolver-typescript: 3.5.2_t7ev3uflic5sb7aktwkyuiuumi
+      eslint-plugin-import: 2.26.0_ajyizmi44oc3hrc35l6ndh7p4e
+      eslint-plugin-jsx-a11y: 6.6.1_eslint@8.35.0
+      eslint-plugin-react: 7.31.11_eslint@8.35.0
+      eslint-plugin-react-hooks: 4.6.0_eslint@8.35.0
       typescript: 4.9.4
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
@@ -13873,7 +14289,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-import-resolver-typescript/3.5.2_w7dy265x2bmlgtc6kmsfumkjde:
+  /eslint-import-resolver-typescript/3.5.2_t7ev3uflic5sb7aktwkyuiuumi:
     resolution: {integrity: sha512-zX4ebnnyXiykjhcBvKIf5TNvt8K7yX6bllTRZ14MiurKPjDpCAZujlszTdB8pcNXhZcOf+god4s9SjQa5GnytQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -13882,8 +14298,8 @@ packages:
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.12.0
-      eslint: 8.34.0
-      eslint-plugin-import: 2.26.0_mcvs2y73sfmcxqzpjj5lr7a2m4
+      eslint: 8.35.0
+      eslint-plugin-import: 2.26.0_ajyizmi44oc3hrc35l6ndh7p4e
       get-tsconfig: 4.2.0
       globby: 13.1.3
       is-core-module: 2.11.0
@@ -13913,6 +14329,35 @@ packages:
       - supports-color
     dev: true
 
+  /eslint-module-utils/2.7.4_6rqs3p4ulfu2tzjnsz6mcumtym:
+    resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.54.0_ddvlikdjy3uujmudifwl7fbpl4
+      debug: 3.2.7
+      eslint: 8.35.0
+      eslint-import-resolver-node: 0.3.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /eslint-module-utils/2.7.4_jwglqn22vmya2cmscqw4soka54:
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
@@ -13938,35 +14383,6 @@ packages:
       debug: 3.2.7
       eslint: 8.32.0
       eslint-import-resolver-node: 0.3.7
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /eslint-module-utils/2.7.4_ry6u65jfokojxl4tm6yj5tidui:
-    resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.52.0_ehfyfk7qbmgzg5nk6xmobqdh3a
-      debug: 3.2.7
-      eslint: 8.34.0
-      eslint-import-resolver-node: 0.3.6
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -14010,7 +14426,7 @@ packages:
       regexpp: 3.2.0
     dev: true
 
-  /eslint-plugin-import/2.26.0_mcvs2y73sfmcxqzpjj5lr7a2m4:
+  /eslint-plugin-import/2.26.0_ajyizmi44oc3hrc35l6ndh7p4e:
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -14020,14 +14436,14 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.52.0_ehfyfk7qbmgzg5nk6xmobqdh3a
+      '@typescript-eslint/parser': 5.54.0_ddvlikdjy3uujmudifwl7fbpl4
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       debug: 2.6.9
       doctrine: 2.1.0
-      eslint: 8.34.0
+      eslint: 8.35.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.4_ry6u65jfokojxl4tm6yj5tidui
+      eslint-module-utils: 2.7.4_6rqs3p4ulfu2tzjnsz6mcumtym
       has: 1.0.3
       is-core-module: 2.11.0
       is-glob: 4.0.3
@@ -14107,7 +14523,7 @@ packages:
       - typescript
     dev: true
 
-  /eslint-plugin-jsx-a11y/6.6.1_eslint@8.34.0:
+  /eslint-plugin-jsx-a11y/6.6.1_eslint@8.35.0:
     resolution: {integrity: sha512-sXgFVNHiWffBq23uiS/JaP6eVR622DqwB4yTzKvGZGcPq6/yZ3WmOZfuBks/vHWo9GaFOqC2ZK4i6+C35knx7Q==}
     engines: {node: '>=4.0'}
     peerDependencies:
@@ -14121,7 +14537,7 @@ packages:
       axobject-query: 2.2.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 8.34.0
+      eslint: 8.35.0
       has: 1.0.3
       jsx-ast-utils: 3.3.3
       language-tags: 1.0.7
@@ -14193,16 +14609,16 @@ packages:
       eslint: 8.32.0
     dev: true
 
-  /eslint-plugin-react-hooks/4.6.0_eslint@8.34.0:
+  /eslint-plugin-react-hooks/4.6.0_eslint@8.35.0:
     resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
     engines: {node: '>=10'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
     dependencies:
-      eslint: 8.34.0
+      eslint: 8.35.0
     dev: true
 
-  /eslint-plugin-react/7.31.11_eslint@8.34.0:
+  /eslint-plugin-react/7.31.11_eslint@8.35.0:
     resolution: {integrity: sha512-TTvq5JsT5v56wPa9OYHzsrOlHzKZKjV+aLgS+55NJP/cuzdiQPC7PfYoUjMoxlffKtvijpk7vA/jmuqRb9nohw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -14212,7 +14628,7 @@ packages:
       array.prototype.flatmap: 1.3.1
       array.prototype.tosorted: 1.1.1
       doctrine: 2.1.0
-      eslint: 8.34.0
+      eslint: 8.35.0
       estraverse: 5.3.0
       jsx-ast-utils: 3.3.3
       minimatch: 3.1.2
@@ -18104,7 +18520,7 @@ packages:
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.20.12
       '@babel/plugin-proposal-optional-chaining': 7.20.7_@babel+core@7.20.12
       '@babel/plugin-transform-modules-commonjs': 7.20.11_@babel+core@7.20.12
-      '@babel/preset-env': 7.20.2_@babel+core@7.20.12
+      '@babel/preset-env': 7.20.2_@babel+core@7.21.0
       '@babel/preset-flow': 7.18.6_@babel+core@7.20.12
       '@babel/preset-typescript': 7.18.6_@babel+core@7.20.12
       '@babel/register': 7.18.9_@babel+core@7.20.12
@@ -19548,19 +19964,11 @@ packages:
     dependencies:
       brace-expansion: 1.1.11
 
-  /minimatch/5.1.2:
-    resolution: {integrity: sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==}
-    engines: {node: '>=10'}
-    dependencies:
-      brace-expansion: 2.0.1
-    dev: true
-
   /minimatch/5.1.6:
     resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
     engines: {node: '>=10'}
     dependencies:
       brace-expansion: 2.0.1
-    dev: false
 
   /minimist/1.2.7:
     resolution: {integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==}
@@ -19852,7 +20260,7 @@ packages:
       react: '>=16.0.0'
       react-dom: '>=16.0.0'
     dependencies:
-      next: 13.0.7_pjwopsidmaokadturxaafygjp4
+      next: 13.0.7_6m24vuloj5ihw4zc5lbsktc4fu
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
@@ -19868,10 +20276,10 @@ packages:
       '@corex/deepmerge': 4.0.29
       '@next/env': 13.0.7
       minimist: 1.2.7
-      next: 13.0.7_pjwopsidmaokadturxaafygjp4
+      next: 13.0.7_6m24vuloj5ihw4zc5lbsktc4fu
     dev: true
 
-  /next/13.0.7_pjwopsidmaokadturxaafygjp4:
+  /next/13.0.7_6m24vuloj5ihw4zc5lbsktc4fu:
     resolution: {integrity: sha512-YfTifqX9vfHm+rSU/H/3xvzOHDkYuMuh4wsvTjiqj9h7qHEF7KHB66X4qrH96Po+ohdid4JY8YVGPziDwdXL0A==}
     engines: {node: '>=14.6.0'}
     hasBin: true
@@ -19895,7 +20303,7 @@ packages:
       postcss: 8.4.14
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      styled-jsx: 5.1.0_2exiyaescjxorpwwmy4ejghgte
+      styled-jsx: 5.1.0_q2tyk3gci27qk4qoatek53e4vi
     optionalDependencies:
       '@next/swc-android-arm-eabi': 13.0.7
       '@next/swc-android-arm64': 13.0.7
@@ -22289,7 +22697,7 @@ packages:
       use-sync-external-store: 1.2.0_react@18.2.0
     dev: false
 
-  /react-select/5.7.0_57czaiyk6rdr5iy5tfs5pior4u:
+  /react-select/5.7.0_3x53adtxznzpnvgkq5pcn7da7q:
     resolution: {integrity: sha512-lJGiMxCa3cqnUr2Jjtg9YHsaytiZqeNOKeibv6WF5zbK/fPegZ1hg3y/9P1RZVLhqBTs0PfqQLKuAACednYGhQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -22297,7 +22705,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.13
       '@emotion/cache': 11.10.5
-      '@emotion/react': 11.10.5_yxdp3dl3eazy3vwpbmv4fq727a
+      '@emotion/react': 11.10.5_l7cfjcftkbbrwrylsnya5ld57q
       '@floating-ui/dom': 1.2.0
       '@types/react-transition-group': 4.4.5
       memoize-one: 6.0.0
@@ -22306,6 +22714,28 @@ packages:
       react-dom: 18.2.0_react@18.2.0
       react-transition-group: 4.4.5_biqbaboplfbrettd7655fr4n2y
       use-isomorphic-layout-effect: 1.1.2_3stiutgnnbnfnf3uowm5cip22i
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@types/react'
+    dev: false
+
+  /react-select/5.7.0_6m24vuloj5ihw4zc5lbsktc4fu:
+    resolution: {integrity: sha512-lJGiMxCa3cqnUr2Jjtg9YHsaytiZqeNOKeibv6WF5zbK/fPegZ1hg3y/9P1RZVLhqBTs0PfqQLKuAACednYGhQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.20.13
+      '@emotion/cache': 11.10.5
+      '@emotion/react': 11.10.5_q2tyk3gci27qk4qoatek53e4vi
+      '@floating-ui/dom': 1.2.0
+      '@types/react-transition-group': 4.4.5
+      memoize-one: 6.0.0
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      react-transition-group: 4.4.5_biqbaboplfbrettd7655fr4n2y
+      use-isomorphic-layout-effect: 1.1.2_react@18.2.0
     transitivePeerDependencies:
       - '@babel/core'
       - '@types/react'
@@ -22328,28 +22758,6 @@ packages:
       react-dom: 18.2.0_react@18.2.0
       react-transition-group: 4.4.5_biqbaboplfbrettd7655fr4n2y
       use-isomorphic-layout-effect: 1.1.2_pmekkgnqduwlme35zpnqhenc34
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@types/react'
-    dev: false
-
-  /react-select/5.7.0_pjwopsidmaokadturxaafygjp4:
-    resolution: {integrity: sha512-lJGiMxCa3cqnUr2Jjtg9YHsaytiZqeNOKeibv6WF5zbK/fPegZ1hg3y/9P1RZVLhqBTs0PfqQLKuAACednYGhQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.20.13
-      '@emotion/cache': 11.10.5
-      '@emotion/react': 11.10.5_2exiyaescjxorpwwmy4ejghgte
-      '@floating-ui/dom': 1.2.0
-      '@types/react-transition-group': 4.4.5
-      memoize-one: 6.0.0
-      prop-types: 15.8.1
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      react-transition-group: 4.4.5_biqbaboplfbrettd7655fr4n2y
-      use-isomorphic-layout-effect: 1.1.2_react@18.2.0
     transitivePeerDependencies:
       - '@babel/core'
       - '@types/react'
@@ -23192,14 +23600,6 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
 
-  /rollup/3.17.1:
-    resolution: {integrity: sha512-8RnSms6rNqHmZK+wiqgnPCqen+rRnUHXkciGDirh7B00g1rX1vpKbPDhuxCvAG2bburoI+W4Q9/PlUB/zYkiYA==}
-    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
-    hasBin: true
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
-
   /rollup/3.17.3:
     resolution: {integrity: sha512-p5LaCXiiOL/wrOkj8djsIDFmyU9ysUxcyW+EKRLHb6TKldJzXpImjcRSR+vgo09DBdofGcOoLOsRyxxG2n5/qQ==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
@@ -23347,7 +23747,7 @@ packages:
       diff-match-patch: 1.0.5
     dev: false
 
-  /sanity-plugin-media/2.0.3_tmfdlqcpexmyewdphhqgtauxrq:
+  /sanity-plugin-media/2.0.3_7u6irrow7qvib7pa4fye3jzaqq:
     resolution: {integrity: sha512-pyFpuoMuhVyNUKxYn2uDchinMgNMBnCVytex1FRniZHyrjVAeIQ63ZHwoLksmSUgWWSaVpEWeEqkC7TIdO/0Xw==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -23378,7 +23778,7 @@ packages:
       react-file-icon: 1.3.0_biqbaboplfbrettd7655fr4n2y
       react-hook-form: 6.15.8_react@18.2.0
       react-redux: 7.2.9_biqbaboplfbrettd7655fr4n2y
-      react-select: 5.7.0_57czaiyk6rdr5iy5tfs5pior4u
+      react-select: 5.7.0_3x53adtxznzpnvgkq5pcn7da7q
       react-virtuoso: 2.19.1_biqbaboplfbrettd7655fr4n2y
       redux: 4.2.0
       redux-observable: 1.2.0_redux@4.2.0+rxjs@6.6.7
@@ -23439,7 +23839,7 @@ packages:
       - react-native
     dev: false
 
-  /sanity-plugin-media/2.0.5_rlhqicyhtx472gnzii6thmn2zu:
+  /sanity-plugin-media/2.0.5_jema4j64tjeydeo632aqr5eb5u:
     resolution: {integrity: sha512-v1SyBezXoiLh2g3olX08cjFpytRF3NkCxCOkFzHz3RVbQQwpYSeazKmGq52XONi/Ci6DpyKmgLWRJCyT/xZc1g==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -23470,7 +23870,7 @@ packages:
       react-file-icon: 1.3.0_biqbaboplfbrettd7655fr4n2y
       react-hook-form: 6.15.8_react@18.2.0
       react-redux: 7.2.9_biqbaboplfbrettd7655fr4n2y
-      react-select: 5.7.0_pjwopsidmaokadturxaafygjp4
+      react-select: 5.7.0_6m24vuloj5ihw4zc5lbsktc4fu
       react-virtuoso: 2.19.1_biqbaboplfbrettd7655fr4n2y
       redux: 4.2.1
       redux-observable: 2.0.0_redux@4.2.1
@@ -24889,7 +25289,7 @@ packages:
       supports-color: 5.5.0
     dev: false
 
-  /styled-jsx/5.1.0_2exiyaescjxorpwwmy4ejghgte:
+  /styled-jsx/5.1.0_q2tyk3gci27qk4qoatek53e4vi:
     resolution: {integrity: sha512-/iHaRJt9U7T+5tp6TRelLnqBqiaIT0HsO0+vgyj8hK2KUk7aejFqRrumqPUlAqDwAj8IbS/1hk3IhBAAK/FCUQ==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
@@ -24902,7 +25302,7 @@ packages:
       babel-plugin-macros:
         optional: true
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       client-only: 0.0.1
       react: 18.2.0
 
@@ -24982,6 +25382,33 @@ packages:
       - sugarss
     dev: true
 
+  /svelte-check/3.0.3_ts33rtakoomyt72aqfijsj6l7q:
+    resolution: {integrity: sha512-ByBFXo3bfHRGIsYEasHkdMhLkNleVfszX/Ns1oip58tPJlKdo5Ssr8kgVIuo5oq00hss8AIcdesuy0Xt0BcTvg==}
+    hasBin: true
+    peerDependencies:
+      svelte: ^3.55.0
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.17
+      chokidar: 3.5.3
+      fast-glob: 3.2.12
+      import-fresh: 3.3.0
+      picocolors: 1.0.0
+      sade: 1.8.1
+      svelte: 3.55.1
+      svelte-preprocess: 5.0.1_m73f5j6cepbqagrf7exwnq7j5a
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - coffeescript
+      - less
+      - postcss
+      - postcss-load-config
+      - pug
+      - sass
+      - stylus
+      - sugarss
+    dev: true
+
   /svelte-hmr/0.15.1_svelte@3.55.1:
     resolution: {integrity: sha512-BiKB4RZ8YSwRKCNVdNxK/GfY+r4Kjgp9jCLEy0DuqAKfmQtpL38cQK3afdpjw4sqSs4PLi3jIPJIFp259NkZtA==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
@@ -24989,6 +25416,56 @@ packages:
       svelte: '>=3.19.0'
     dependencies:
       svelte: 3.55.1
+    dev: true
+
+  /svelte-preprocess/5.0.1_m73f5j6cepbqagrf7exwnq7j5a:
+    resolution: {integrity: sha512-0HXyhCoc9rsW4zGOgtInylC6qj259E1hpFnJMJWTf+aIfeqh4O/QHT31KT2hvPEqQfdjmqBR/kO2JDkkciBLrQ==}
+    engines: {node: '>= 14.10.0'}
+    requiresBuild: true
+    peerDependencies:
+      '@babel/core': ^7.10.2
+      coffeescript: ^2.5.1
+      less: ^3.11.3 || ^4.0.0
+      postcss: ^7 || ^8
+      postcss-load-config: ^2.1.0 || ^3.0.0 || ^4.0.0
+      pug: ^3.0.0
+      sass: ^1.26.8
+      stylus: ^0.55.0
+      sugarss: ^2.0.0 || ^3.0.0 || ^4.0.0
+      svelte: ^3.23.0
+      typescript: ^3.9.5 || ^4.0.0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      coffeescript:
+        optional: true
+      less:
+        optional: true
+      postcss:
+        optional: true
+      postcss-load-config:
+        optional: true
+      pug:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@babel/core': 7.21.0
+      '@types/pug': 2.0.6
+      '@types/sass': 1.43.1
+      detect-indent: 6.1.0
+      magic-string: 0.27.0
+      postcss: 8.4.21
+      sorcery: 0.11.0
+      strip-indent: 3.0.0
+      svelte: 3.55.1
+      typescript: 4.9.5
     dev: true
 
   /svelte-preprocess/5.0.1_wluf2ob37pj6ulfkqvmfgq24j4:
@@ -26825,7 +27302,7 @@ packages:
       esbuild: 0.16.17
       postcss: 8.4.21
       resolve: 1.22.1
-      rollup: 3.17.1
+      rollup: 3.17.0
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
@@ -27748,10 +28225,6 @@ packages:
 
   /xstate/4.35.3:
     resolution: {integrity: sha512-/vM8la6OPcmT2P4R8p37P/Pzo8fTeEjvg+lxCfQ7vTeJg6NmzPHDJ5RdlrGfojEIabMxKW22Tm2kz8oV390Awg==}
-    dev: true
-
-  /xstate/4.35.4:
-    resolution: {integrity: sha512-mqRBYHhljP1xIItI4xnSQNHEv6CKslSM1cOGmvhmxeoDPAZgNbhSUYAL5N6DZIxRfpYY+M+bSm3mUFHD63iuvg==}
     dev: true
 
   /xstate/4.36.0:


### PR DESCRIPTION
This PR:

- make `core` package ESM only;
- split it into 4 submodules (config, utils, domains, script);
- fix all imports