### PR TITLE
add page link

### DIFF
--- a/apps/website/src/infrastructure/sanity/schemas/customFields/blockContentField.tsx
+++ b/apps/website/src/infrastructure/sanity/schemas/customFields/blockContentField.tsx
@@ -1,4 +1,4 @@
-import { IconExternalLink, IconLink } from '@tabler/icons-react';
+import { IconExternalLink, IconHash, IconLink } from '@tabler/icons-react';
 import { defineField } from 'sanity';
 
 import { highlightMarkerField } from './highlightMarkerField';
@@ -93,12 +93,28 @@ export const blockContentField = defineField({
                 title: `URL`,
                 name: `href`,
                 type: `url`,
+                validation: (Rule) => Rule.uri({ scheme: [`http`, `https`] }),
               },
               {
                 title: `Open in new window`,
                 name: `blank`,
                 type: `boolean`,
-                initialValue: false,
+                initialValue: true,
+              },
+            ],
+          },
+          {
+            title: `Page Link`,
+            name: `pageLink`,
+            type: `object`,
+            icon: () => <IconHash />,
+            fields: [
+              {
+                title: `Heading ID`,
+                name: `id`,
+                type: `string`,
+                description: `The ID of the heading you want to link to`,
+                validation: (Rule) => Rule.required(),
               },
             ],
           },

--- a/apps/website/src/ui/PortableText/PageLink.astro
+++ b/apps/website/src/ui/PortableText/PageLink.astro
@@ -1,0 +1,16 @@
+---
+type Props = {
+  node: {
+    children: { text: string }[];
+    markDef: {
+      id: string;
+    };
+  };
+};
+
+const { children, markDef } = Astro.props.node;
+const [child] = children;
+const { id } = markDef;
+---
+
+<a href={`#${id}`}>{child.text}</a>

--- a/apps/website/src/ui/PortableText/PortableText.astro
+++ b/apps/website/src/ui/PortableText/PortableText.astro
@@ -11,6 +11,7 @@ import Highlight from './Highlight.astro';
 import Image from './Image.astro';
 import { ImageSlider } from './ImageSlider';
 import InternalLink from './InternalLink.astro';
+import PageLink from './PageLink.astro';
 import Strikethrough from './Strikethrough.astro';
 import { Tweet } from './Tweet';
 import { YouTube } from './YouTube';
@@ -40,6 +41,7 @@ const components = {
     strikethrough: Strikethrough,
     highlight: Highlight,
     internalLink: InternalLink,
+    pageLink: PageLink,
   },
   block: {
     h2: HeadingWithLink,


### PR DESCRIPTION
This PR implements a "page link" marker to be able to reference a link from a heading it (e.g., `<a href="#read-more" />`)


![Screenshot 2023-03-18 at 12 25 10](https://user-images.githubusercontent.com/12464600/226102314-5a44b06c-c42e-4be3-90ec-e8f5dfbd73ee.png)
