### PR TITLE
Adding overflow-hidden for large breadcrumbs texts

### DIFF
--- a/apps/website/src/ui/Breadcrumbs/Breadcrumb.svelte
+++ b/apps/website/src/ui/Breadcrumbs/Breadcrumb.svelte
@@ -8,7 +8,7 @@
 </script>
 
 <li
-  class={mergeClasses('flex items-center', !isLink && 'truncate text-ellipsis')}
+  class={mergeClasses('flex items-center', !isLink && 'truncate text-ellipsis overflow-hidden')}
 >
   {#if 'href' in crumb}
     <a href={crumb.href}>{crumb.label}</a>


### PR DESCRIPTION
Hi, man, I found this UI issue on the mobile version of your website.

I think adding an overflow hidden will fix it. I'm not sure bc I couldn't run your website locally, I might not have the .env variables or something.

## Before:
<img width="513" alt="Screenshot 2023-08-12 at 10 26 07" src="https://github.com/raulfdm/raulmelo-studio/assets/19225674/6fb09711-a3eb-4923-9942-68418d2c1535">


## Now:
<img width="549" alt="Screenshot 2023-08-12 at 10 25 31" src="https://github.com/raulfdm/raulmelo-studio/assets/19225674/1302cf04-067c-4f40-9f8a-0a82eeadbf7a">

Cheers.